### PR TITLE
Purchase Scans Respect Settings for Quantity Unit Purchase and Quantity Unit Stock factor.

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/ScanBatchActivity.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/ScanBatchActivity.java
@@ -503,7 +503,7 @@ public class ScanBatchActivity extends AppCompatActivity
     public void purchaseProduct() {
         JSONObject body = new JSONObject();
         try {
-            body.put("amount", 1);
+            body.put("amount", currentProductDetails.getProduct().getQuFactorPurchaseToStock());
             body.put("transaction_type", "purchase");
             body.put("best_before_date", bestBeforeDate);
             if(!price.isEmpty()) {
@@ -533,7 +533,7 @@ public class ScanBatchActivity extends AppCompatActivity
                             findViewById(R.id.barcode_scan_batch),
                             getString(
                                     R.string.msg_purchased,
-                                    String.valueOf(1),
+                                    String.valueOf(currentProductDetails.getProduct().getQuFactorPurchaseToStock()),
                                     currentProductDetails.getQuantityUnitStock().getName(),
                                     currentProductDetails.getProduct().getName()
                             ), Snackbar.LENGTH_LONG


### PR DESCRIPTION
Resolves #13 

This may need some more work in terms of settings to use this behavior vs not. (but I was not sure how to add settings to the app)