### PR TITLE
improve formatting of fastlane app description

### DIFF
--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -1,13 +1,8 @@
-Grocy Android ist ein quelloffener Android Client für grocy. <a href="https://grocy.info/">grocy</a> (<a href="https://github.com/grocy/grocy">Quellcode</a>) ist eine selbst gehostete Webanwendung zur Lebensmittel- und Haushaltsverwaltung.
+<p>Grocy Android ist ein quelloffener Android Client für grocy. <a href="https://grocy.info/">grocy</a> (<a href="https://github.com/grocy/grocy">Quellcode</a>) ist eine selbst gehostete Webanwendung zur Lebensmittel- und Haushaltsverwaltung.</p>
+<p>Grocy Android benutzt grocy's offizielle API, um dir eine schöne Benutzeroberfläche auf deinem Handy zu geben, zusammen mit einem schnellen Barcode-Scanner und Stapelverarbeitung. Alles was du brauchst, um deine Lebensmittel effizient zu verwalten.</p>
+<p><br><b>Diese App benötigt eine selbst gehostete Instanz der grocy-Webanwendung. Sie dient als Zusatz und kann daher keine Lebensmittel ohne einen Server verwalten. Du kannst die App aber testen, indem du die Demo-Option auf dem Anmeldebildschirm wählst.</b><br></p>
 
-Grocy Android benutzt grocy's offizielle API, um dir eine schöne Benutzeroberfläche auf deinem Handy zu geben, zusammen mit einem schnellen Barcode-Scanner und Stapelverarbeitung. Alles was du brauchst, um deine Lebensmittel effizient zu verwalten.
-
-<b>Diese App benötigt eine selbst gehostete Instanz der grocy-Webanwendung. Sie dient als Zusatz und kann daher keine Lebensmittel ohne einen Server verwalten.
-Du kannst die App aber testen, indem du die Demo-Option auf dem Anmeldebildschirm wählst.</b>
-
-<b>Fähigkeiten:</b>
-
-<ul>
+<p><b>Fähigkeiten:</b></p><ul>
    <li>Bestandsübersicht</li>
    <li>Einkaufsliste mit Offline-Unterstützung</li>
    <li>Einkaufsmodus (große Klickelemente)</li>
@@ -21,12 +16,9 @@ Du kannst die App aber testen, indem du die Demo-Option auf dem Anmeldebildschir
    <li>Kleine App-Größe (~6MB)</li>
 </ul>
 
-<b>Beteiligung:</b>
-Wenn du einen Fehler bemerkst oder Verbesserungsvorschläge hast, zögere nicht, uns in der App Feedback zu geben, eine E-Mail zu schreiben oder <a href="https://github.com/patzly/grocy-android/issues/new">ein neues Issue</a> auf GitHub zu öffnen.
-Wie die grocy-Webanwendung, kann auch dieses Projekt übersetzt werden. Bitte besuche unsere GitHub-Seite für mehr Informationen.
+<p><br><b>Beteiligung:</b></p>
+<p>Wenn du einen Fehler bemerkst oder Verbesserungsvorschläge hast, zögere nicht, uns in der App Feedback zu geben, eine E-Mail zu schreiben oder <a href="https://github.com/patzly/grocy-android/issues/new">ein neues Issue</a> auf GitHub zu öffnen. Wie die grocy-Webanwendung, kann auch dieses Projekt übersetzt werden. Bitte besuche unsere GitHub-Seite für mehr Informationen.</p>
 
-<b>Kompatibilität:</b>
-Grocy Android benötigt mindestens grocy 2.7.0 auf deinem Server.
-Es ist auch möglich, das grocy Add-on auf einem Hass.io server zu verwenden. Die In-App-Hilfe beschreibt, wie dies klappt.
-
-Wir danken dem Entwickler von grocy, Bernd Bestel, ohne dessen großartige Arbeit diese App nicht möglich wäre.
+<p><br><b>Kompatibilität:</b></p>
+<p>Grocy Android benötigt mindestens grocy 2.7.0 auf deinem Server. Es ist auch möglich, das grocy Add-on auf einem Hass.io server zu verwenden. Die In-App-Hilfe beschreibt, wie dies klappt.<br></p>
+<p>Wir danken dem Entwickler von grocy, Bernd Bestel, ohne dessen großartige Arbeit diese App nicht möglich wäre.</p>

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,13 +1,7 @@
-Grocy Android is an open-source Android client for grocy. <a href="https://grocy.info/">grocy</a> (<a href="https://github.com/grocy/grocy">source code</a>) is a self-hosted groceries & household management solution for your home.
-
-Grocy Android uses grocy's official API to provide you a beautiful interface on your phone with powerful barcode scanning and intuitive batch processing, all what you need to efficiently manage your groceries.
-
-<b>This app requires a running self-hosted instance of the grocy server application. It is a companion app, therefore it cannot run standalone or manage products itself!
-You can try and test all features using the demo option available on the login screen.</b>
-
-<b>Features:</b>
-
-<ul>
+<p>Grocy Android is an open-source Android client for grocy. <a href="https://grocy.info/">grocy</a> (<a href="https://github.com/grocy/grocy">source code</a>) is a self-hosted groceries & household management solution for your home.</p>
+<p>Grocy Android uses grocy's official API to provide you a beautiful interface on your phone with powerful barcode scanning and intuitive batch processing, all what you need to efficiently manage your groceries.</p>
+<p><br><b>This app requires a running self-hosted instance of the grocy server application. It is a companion app, therefore it cannot run standalone or manage products itself! You can try and test all features using the demo option available on the login screen.</b><br></p>
+<p><b>Features:</b></p><ul>
    <li>Stock overview</li>
    <li>Shopping lists with offline support</li>
    <li>In-store shopping mode (big UI elements)</li>
@@ -21,12 +15,9 @@ You can try and test all features using the demo option available on the login s
    <li>Small app size (~6MB)</li>
 </ul>
 
-<b>Contribution:</b>
-If you run into a bug or miss a feature, feel free to give feedback in the app, send us an email or <a href="https://github.com/patzly/grocy-android/issues/new">open an issue on GitHub</a>.
-Like the grocy project, Grocy Android can be translated, too. Please go to our GitHub page for more information.
+<p><br><b>Contribution:</b></p>
+<p>If you run into a bug or miss a feature, feel free to give feedback in the app, send us an email or <a href="https://github.com/patzly/grocy-android/issues/new">open an issue on GitHub</a>. Like the grocy project, Grocy Android can be translated, too. Please go to our GitHub page for more information.</p>
 
-<b>Compatibility:</b>
-Grocy Android requires at least grocy 2.7.0 on your server.
-It is also possible to use the grocy Add-on on a Hass.io server. Our in-app help explains how to do that.
-
-We'd like to thank the developer of Grocy, Bernd Bestel, without whose great work this app would never have been possible.
+<p><br><b>Compatibility:</b></p>
+<p>Grocy Android requires at least grocy 2.7.0 on your server. It is also possible to use the grocy Add-on on a Hass.io server. Our in-app help explains how to do that.</p>
+<p><br>We'd like to thank the developer of Grocy, Bernd Bestel, without whose great work this app would never have been possible.</p>


### PR DESCRIPTION
Looks nicer when rendered :wink: Besides, you could also remove images from `de-DE` if they are identical to those in `en-US` (currently it seems they all are); what's not there in one language should be taken from `en-US`, which usually serves as fallback.