### PR TITLE
Make message duration adjustable

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/fragment/SettingsCatBehaviorFragment.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/fragment/SettingsCatBehaviorFragment.java
@@ -28,6 +28,7 @@ import android.view.ViewGroup;
 import android.view.animation.Animation;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.PreferenceManager;
 import java.util.List;
@@ -47,6 +48,7 @@ public class SettingsCatBehaviorFragment extends BaseFragment {
 
   private FragmentSettingsCatBehaviorBinding binding;
   private MainActivity activity;
+  private MutableLiveData<String> messageDurationLive;
 
   @Override
   public View onCreateView(
@@ -103,6 +105,10 @@ public class SettingsCatBehaviorFragment extends BaseFragment {
     updateShortcuts();
 
     setForPreviousDestination(Constants.ARGUMENT.ANIMATED, false);
+  }
+
+  public MutableLiveData<String> getmessageDuration() {
+    return messageDurationLive;
   }
 
   @Override

--- a/app/src/main/java/xyz/zedler/patrick/grocy/util/Constants.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/util/Constants.java
@@ -110,6 +110,7 @@ public final class Constants {
       public final static String FOOD_FACTS = "food_facts";
       public final static String EXPAND_BOTTOM_SHEETS = "expand_bottom_sheets";
       public final static String SPEED_UP_START = "speed_up_start";
+      public final static String MESSAGE_DURATION = "message_duration";
     }
 
     public final static class SCANNER {
@@ -170,6 +171,7 @@ public final class Constants {
       public final static boolean FOOD_FACTS = false;
       public final static boolean EXPAND_BOTTOM_SHEETS = false;
       public final static boolean SPEED_UP_START = false;
+      public final static int MESSAGE_DURATION = 20;
     }
 
     public final static class SCANNER {

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/ConsumeViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/ConsumeViewModel.java
@@ -460,7 +460,9 @@ public class ConsumeViewModel extends BaseViewModel {
                 getString(R.string.action_undo),
                 v -> undoTransaction(transId)
             );
-            snackbarMessage.setDurationSecs(20);
+            snackbarMessage.setDurationSecs(sharedPrefs.getInt(
+                    Constants.SETTINGS.BEHAVIOR.MESSAGE_DURATION,
+                    Constants.SETTINGS_DEFAULT.BEHAVIOR.MESSAGE_DURATION));
           }
           showSnackbar(snackbarMessage);
           sendEvent(Event.CONSUME_SUCCESS);

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/InventoryViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/InventoryViewModel.java
@@ -411,7 +411,9 @@ public class InventoryViewModel extends BaseViewModel {
                 getString(R.string.action_undo),
                 v -> undoTransaction(transId)
             );
-            snackbarMessage.setDurationSecs(20);
+            snackbarMessage.setDurationSecs(sharedPrefs.getInt(
+                    Constants.SETTINGS.BEHAVIOR.MESSAGE_DURATION,
+                    Constants.SETTINGS_DEFAULT.BEHAVIOR.MESSAGE_DURATION));
           }
           showSnackbar(snackbarMessage);
           sendEvent(Event.TRANSACTION_SUCCESS);

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/PurchaseViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/PurchaseViewModel.java
@@ -573,7 +573,9 @@ public class PurchaseViewModel extends BaseViewModel {
             getString(R.string.action_undo),
             v -> undoTransaction(transId, shoppingListItem)
         );
-        snackbarMessage.setDurationSecs(20);
+        snackbarMessage.setDurationSecs(sharedPrefs.getInt(
+                Constants.SETTINGS.BEHAVIOR.MESSAGE_DURATION,
+                Constants.SETTINGS_DEFAULT.BEHAVIOR.MESSAGE_DURATION));
       }
       showSnackbar(snackbarMessage);
       sendEvent(Event.TRANSACTION_SUCCESS);

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/SettingsViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/SettingsViewModel.java
@@ -742,6 +742,14 @@ public class SettingsViewModel extends BaseViewModel {
     needsRestartLive.setValue(true);
   }
 
+  public void setMessageDuration(int duration) {
+    sharedPrefs.edit().putInt(BEHAVIOR.MESSAGE_DURATION, duration).apply();
+  }
+
+  public int getMessageDuration() {
+    return sharedPrefs.getInt(BEHAVIOR.MESSAGE_DURATION, SETTINGS_DEFAULT.BEHAVIOR.MESSAGE_DURATION);
+  }
+
   public void showProxyPortBottomSheet() {
     Bundle bundle = new Bundle();
     bundle.putInt(Constants.ARGUMENT.NUMBER, getProxyPort());

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/SettingsViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/SettingsViewModel.java
@@ -192,6 +192,14 @@ public class SettingsViewModel extends BaseViewModel {
 
   public void showLoadingTimeoutBottomSheet() {
     Bundle bundle = new Bundle();
+    bundle.putInt(Constants.ARGUMENT.NUMBER, getMessageDuration());
+    bundle.putString(Constants.ARGUMENT.HINT, getString(R.string.property_seconds));
+    bundle.putString(ARGUMENT.TYPE, BEHAVIOR.MESSAGE_DURATION);
+    showBottomSheet(new InputBottomSheet(), bundle);
+  }
+
+  public void showMessageDurationBottomSheet() {
+    Bundle bundle = new Bundle();
     bundle.putInt(Constants.ARGUMENT.NUMBER, getLoadingTimeout());
     bundle.putString(Constants.ARGUMENT.HINT, getString(R.string.property_seconds));
     bundle.putString(ARGUMENT.TYPE, NETWORK.LOADING_TIMEOUT);

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/TransferViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/TransferViewModel.java
@@ -448,7 +448,9 @@ public class TransferViewModel extends BaseViewModel {
                 getString(R.string.action_undo),
                 v -> undoTransaction(transId)
             );
-            snackbarMessage.setDurationSecs(20);
+            snackbarMessage.setDurationSecs(sharedPrefs.getInt(
+                    Constants.SETTINGS.BEHAVIOR.MESSAGE_DURATION,
+                    Constants.SETTINGS_DEFAULT.BEHAVIOR.MESSAGE_DURATION));
           }
           showSnackbar(snackbarMessage);
           sendEvent(Event.CONSUME_SUCCESS);

--- a/app/src/main/res/layout/fragment_settings_cat_behavior.xml
+++ b/app/src/main/res/layout/fragment_settings_cat_behavior.xml
@@ -265,32 +265,27 @@
 
         </LinearLayout>
 
-      </LinearLayout>
+        <LinearLayout
+            style="@style/Widget.Grocy.LinearLayout.ListItem.TwoLine.Icon.Clickable"
+            android:onClick="@{() -> viewModel.showMessageDurationBottomSheet()}"
+            clickUtil="@{clickUtil}">
 
-      <LinearLayout
-          style="@style/Widget.Grocy.LinearLayout.ListItem.TwoLine.Icon.Clickable"
-          android:onClick="@{() -> viewModel.showMessageDurationBottomSheet()}"
-          clickUtil="@{clickUtil}">
+          <LinearLayout style="@style/Widget.Grocy.LinearLayout.ListItem.TextBox">
 
-        <ImageView
-            android:id="@+id/image_default_amount_purchase"
-            style="@style/Widget.Grocy.ImageView.ListItem.Icon"
-            android:src="@drawable/ic_round_scatter_plot_anim"
-            tools:ignore="ContentDescription" />
+            <TextView
+                style="@style/Widget.Grocy.TextView.ListItem.OverLine"
+                android:text="@string/setting_message_duration" />
 
-        <LinearLayout style="@style/Widget.Grocy.LinearLayout.ListItem.TextBox">
+            <TextView
+                style="@style/Widget.Grocy.TextView.ListItem.Title"
+                android:text="@{viewModel.messageDuration}"/>
 
-          <TextView
-              style="@style/Widget.Grocy.TextView.ListItem.OverLine"
-              android:text="@string/setting_default_amount_purchase" />
-
-          <TextView
-              style="@style/Widget.Grocy.TextView.ListItem.Title"
-              android:text="@{viewModel.messageDuration}"/>
+          </LinearLayout>
 
         </LinearLayout>
 
       </LinearLayout>
+
 
     </androidx.core.widget.NestedScrollView>
 

--- a/app/src/main/res/layout/fragment_settings_cat_behavior.xml
+++ b/app/src/main/res/layout/fragment_settings_cat_behavior.xml
@@ -267,6 +267,31 @@
 
       </LinearLayout>
 
+      <LinearLayout
+          style="@style/Widget.Grocy.LinearLayout.ListItem.TwoLine.Icon.Clickable"
+          android:onClick="@{() -> viewModel.showMessageDurationBottomSheet()}"
+          clickUtil="@{clickUtil}">
+
+        <ImageView
+            android:id="@+id/image_default_amount_purchase"
+            style="@style/Widget.Grocy.ImageView.ListItem.Icon"
+            android:src="@drawable/ic_round_scatter_plot_anim"
+            tools:ignore="ContentDescription" />
+
+        <LinearLayout style="@style/Widget.Grocy.LinearLayout.ListItem.TextBox">
+
+          <TextView
+              style="@style/Widget.Grocy.TextView.ListItem.OverLine"
+              android:text="@string/setting_default_amount_purchase" />
+
+          <TextView
+              style="@style/Widget.Grocy.TextView.ListItem.Title"
+              android:text="@{viewModel.messageDuration}"/>
+
+        </LinearLayout>
+
+      </LinearLayout>
+
     </androidx.core.widget.NestedScrollView>
 
   </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -796,6 +796,7 @@
   <string name="setting_proxy_port_description">Ihre Proxy-Portnummer</string>
   <string name="setting_synchronized">Die folgende Einstellung wird mit Ihrem Server synchronisiert.</string>
   <string name="settings_synchronized">Diese Einstellungen werden mit Ihrem Server synchronisiert.</string>
+  <string name="setting_message_duration">Anzeigedauer von Nachrichten</string>
 
   <!-- This is the URL of the demo instance on grocy.info . Replace 'en' with the abbreviation of the translation language. If your language is not available as demo language, take 'en'.
   Examples: 'de' for German; 'fr' for French -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -810,6 +810,7 @@
   <string name="setting_proxy_port_description">Your proxy\'s port number</string>
   <string name="setting_synchronized">The option below is synchronized with your server.</string>
   <string name="settings_synchronized">These settings are synchronized with your server.</string>
+  <string name="setting_message_duration">Displaytime for messages</string>
 
   <string name="barcode_format_code128" translatable="false">Code 128</string>
   <string name="barcode_format_code39" translatable="false">Code 39</string>


### PR DESCRIPTION
Giving the user a possibility to revert his / her choices after adding / consuming a product by displaying a snackbar is a nice feature. But displaying the message for 20 seconds is too long for me. So I introduced a setting that allows the users (and myself) to adjust the display duration to their needs.

Need a review and maybe some instructions for improving the code. Used to work with android a long time ago and forgot nearly everything. Might made some mistakes. 
Please be kind :)