### PR TITLE
Fix/add sorting of quantites, locations and stores

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/fragment/MasterProductCatLocationFragment.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/fragment/MasterProductCatLocationFragment.java
@@ -40,6 +40,7 @@ import xyz.zedler.patrick.grocy.model.Location;
 import xyz.zedler.patrick.grocy.model.SnackbarMessage;
 import xyz.zedler.patrick.grocy.model.Store;
 import xyz.zedler.patrick.grocy.util.Constants;
+import xyz.zedler.patrick.grocy.util.SortUtil;
 import xyz.zedler.patrick.grocy.viewmodel.MasterProductCatLocationViewModel;
 
 public class MasterProductCatLocationFragment extends BaseFragment {
@@ -163,6 +164,9 @@ public class MasterProductCatLocationFragment extends BaseFragment {
       viewModel.showErrorMessage();
       return;
     }
+
+    SortUtil.sortLocationsByName(requireContext(), locations, true);
+
     Bundle bundle = new Bundle();
     bundle.putParcelableArrayList(Constants.ARGUMENT.LOCATIONS, locations);
     Location location = viewModel.getFormData().getLocationLive().getValue();
@@ -177,9 +181,13 @@ public class MasterProductCatLocationFragment extends BaseFragment {
       viewModel.showErrorMessage();
       return;
     }
+
+    SortUtil.sortStoresByName(requireContext(), stores, true);
+
     if (stores != null && !stores.isEmpty() && stores.get(0).getId() != -1) {
       stores.add(0, new Store(-1, getString(R.string.subtitle_none_selected)));
     }
+
     Bundle bundle = new Bundle();
     bundle.putParcelableArrayList(Constants.ARGUMENT.STORES, stores);
     Store store = viewModel.getFormData().getStoreLive().getValue();

--- a/app/src/main/java/xyz/zedler/patrick/grocy/util/SortUtil.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/util/SortUtil.java
@@ -160,10 +160,19 @@ public class SortUtil {
       return;
     }
     Locale locale = LocaleUtil.getUserLocale(context);
-    Collections.sort(stores, (item1, item2) -> Collator.getInstance(locale).compare(
-        (ascending ? item1 : item2).getName().toLowerCase(),
-        (ascending ? item2 : item1).getName().toLowerCase()
-    ));
+    Collections.sort(stores, (item1, item2) -> {
+        // items with id == -1 ("None selected") shall always be on top.
+        if (item1.getId() == -1) {
+          return -1;
+        }
+        if (item2.getId() == -1) {
+          return 1;
+        }
+
+        return Collator.getInstance(locale).compare(
+                (ascending ? item1 : item2).getName().toLowerCase(),
+                (ascending ? item2 : item1).getName().toLowerCase());
+      });
   }
 
   public static void sortProductGroupsByName(
@@ -190,10 +199,20 @@ public class SortUtil {
       return;
     }
     Locale locale = LocaleUtil.getUserLocale(context);
-    Collections.sort(quantityUnits, (item1, item2) -> Collator.getInstance(locale).compare(
-        (ascending ? item1 : item2).getName().toLowerCase(),
-        (ascending ? item2 : item1).getName().toLowerCase()
-    ));
+    Collections.sort(quantityUnits, (item1, item2) -> {
+      // Units with id == -1 ("None selected") shall always be on top.
+      if (item1.getId() == -1) {
+        return -1;
+      }
+      if (item2.getId() == -1) {
+        return 1;
+      }
+
+      return Collator.getInstance(locale).compare(
+              (ascending ? item1 : item2).getName().toLowerCase(),
+              (ascending ? item2 : item1).getName().toLowerCase()
+      );
+    });
   }
 
   public static void sortShoppingListItemsByName(

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/MasterProductCatQuantityUnitViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/MasterProductCatQuantityUnitViewModel.java
@@ -43,6 +43,7 @@ import xyz.zedler.patrick.grocy.model.QuantityUnit;
 import xyz.zedler.patrick.grocy.repository.MasterProductRepository;
 import xyz.zedler.patrick.grocy.util.Constants;
 import xyz.zedler.patrick.grocy.util.PrefsUtil;
+import xyz.zedler.patrick.grocy.util.SortUtil;
 
 public class MasterProductCatQuantityUnitViewModel extends BaseViewModel {
 
@@ -173,16 +174,22 @@ public class MasterProductCatQuantityUnitViewModel extends BaseViewModel {
       showMessage(getString(R.string.msg_help_qu_stock));
       return;
     }
-    ArrayList<QuantityUnit> qUs = formData.getQuantityUnitsLive().getValue();
-    if (qUs == null) {
+    ArrayList<QuantityUnit> quantityUnits = formData.getQuantityUnitsLive().getValue();
+    SortUtil.sortQuantityUnitsByName(
+            this.getApplication().getApplicationContext(),
+            quantityUnits,
+            true);
+
+    if (quantityUnits == null) {
       showErrorMessage();
       return;
     }
-    if (qUs != null && !qUs.isEmpty() && qUs.get(0).getId() != -1) {
-      qUs.add(0, new QuantityUnit(-1, getString(R.string.subtitle_none_selected)));
+
+    if (quantityUnits != null && !quantityUnits.isEmpty() && quantityUnits.get(0).getId() != -1) {
+      quantityUnits.add(0, new QuantityUnit(-1, getString(R.string.subtitle_none_selected)));
     }
     Bundle bundle = new Bundle();
-    bundle.putParcelableArrayList(Constants.ARGUMENT.QUANTITY_UNITS, qUs);
+    bundle.putParcelableArrayList(Constants.ARGUMENT.QUANTITY_UNITS, quantityUnits);
     QuantityUnit quantityUnit;
     if (type == FormDataMasterProductCatQuantityUnit.STOCK) {
       quantityUnit = formData.getQuStockLive().getValue();


### PR DESCRIPTION
The bottom sheets for selecting quantities, stores and locations
that open up when editing product master data did not contain the
elements in a sorted manner.

This PR fixes that.

However, there is a hacky workaround in here:
The "None selected" entry for both quantities and stores needs to
be on top in order to not be added again and again and again.
The algorithm simply checks the first element for its ID...

Therefore this, the ID = -1 gets pushed to the top during the
sorting *by name*, which is kind of counter-intuitive...

I think it would be slightly better to check for the "None selected"-element
_at the place where it is added_, but still, I think it is kind of messy:
A real solution to this would be to not modify the list of another element
when displaying it and rather just display a copy.

However, I did not dive into the possible consequences of _that_, therefore
i stayed with the hack. \*shrug\*

fixes #473 