### PR TITLE
Create new strings from raw text in product page

### DIFF
--- a/app/src/main/res/layout/fragment_master_product.xml
+++ b/app/src/main/res/layout/fragment_master_product.xml
@@ -203,7 +203,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="@string/description_input_product_optional_properties"
+                  android:text="@string/subtitle_product_optional_properties"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>
@@ -243,7 +243,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="@string/description_input_product_default_location"
+                  android:text="@string/subtitle_product_default_location"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>
@@ -283,7 +283,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="@string/description_input_product_due_date"
+                  android:text="@string/subtitle_product_due_date"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>
@@ -322,7 +322,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="@string/description_input_product_quantity_unit"
+                  android:text="@string/subtitle_product_quantity_unit"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>
@@ -361,7 +361,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="@string/description_input_product_amount"
+                  android:text="@string/subtitle_product_amount"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>

--- a/app/src/main/res/layout/fragment_master_product.xml
+++ b/app/src/main/res/layout/fragment_master_product.xml
@@ -203,7 +203,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="State, Parent product, Description, Product group, Energy, Picture"
+                  android:text="@string/description_input_product_optional_properties"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>
@@ -243,7 +243,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="Location, Store"
+                  android:text="@string/description_input_product_default_location"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>
@@ -283,7 +283,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="Type, Default days, after opened, freezing, thawing"
+                  android:text="@string/description_input_product_due_date"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>
@@ -322,7 +322,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="Stock, Purchase default"
+                  android:text="@string/description_input_product_quantity_unit"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>
@@ -361,7 +361,7 @@
 
                 <TextView
                   style="@style/Widget.Grocy.TextView.ListItem.Description"
-                  android:text="Min. stock, Quick consume, Factor, Tare weight handling"
+                  android:text="@string/description_input_product_amount"
                   android:visibility="@{formData.displayHelpLive ? View.VISIBLE : View.GONE}" />
 
               </LinearLayout>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -510,6 +510,11 @@
   <string name="description_input_product_option1">Créer un nouveau produit et utiliser l\'entrée comme nom</string>
   <string name="description_input_product_option2">Créer un produit et utiliser l\'entrée en tant que code-barres</string>
   <string name="description_input_product_option3">Ajouter en tant que code-barres à un produit existant</string>
+  <string name="description_input_product_amount">Stock min., Consommation rapide, Facteur, Tarage</string>
+  <string name="description_input_product_default_location">Emplacement, Magasin</string>
+  <string name="description_input_product_due_date">Type, Date par défaut (après ouverture, congélation, décongélation)</string>
+  <string name="description_input_product_optional_properties">État, Produit parent, Description, Groupe de produits, Énergie, Image</string>
+  <string name="description_input_product_quantity_unit">Stock, Format à l\'achat par défaut</string>
   <!-- Context: Clear shopping list -->
   <string name="description_clear_shopping_list_option1">Ne supprimer que les produits validés</string>
   <!-- Context: Clear shopping list -->
@@ -664,7 +669,6 @@
   <string name="property_active">Actif</string>
   <!--The same string is also in the web interface: Product edit form (maybe you can get the translation from there to prevent different translations for the same string) -->
   <string name="property_never_show">Ne jamais afficher sur l\'aperçu du stock</string>
-  <string name="property_number">Nombre</string>
   <!--The same string is also in the web interface: Product edit form (maybe you can get the translation from there to prevent different translations for the same string) -->
   <string name="property_enable_tare_weight">Activer la gestion du tarage du poids</string>
   <!--The same string is also in the web interface: Product edit form (maybe you can get the translation from there to prevent different translations for the same string) -->
@@ -880,4 +884,5 @@
   <!-- This is the URL of the demo instance on grocy.info . Replace 'en' with the abbreviation of the translation language. If your language is not available as demo language, take 'en'.
   Examples: 'de' for German; 'fr' for French -->
   <string name="url_grocy_demo">https://fr.demo.grocy.info</string>
-  </resources>
+
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -504,17 +504,17 @@
   <string name="subtitle_barcode">Code-barres : %1$s</string>
   <string name="subtitle_feature_disabled">Fonctionnalité désactivée</string>
   <string name="subtitle_date_from_input">Date de saisie :\n%1$s</string>
+  <string name="subtitle_product_amount">Stock min., Consommation rapide, Facteur, Tarage</string>
+  <string name="subtitle_product_default_location">Emplacement, Magasin</string>
+  <string name="subtitle_product_due_date">Type, Date par défaut (après ouverture, congélation, décongélation)</string>
+  <string name="subtitle_product_optional_properties">État, Produit parent, Description, Groupe de produits, Énergie, Image</string>
+  <string name="subtitle_product_quantity_unit">Stock, Format à l\'achat par défaut</string>
 
   <string name="description_input_product_part1">Le champ du produit contient :</string>
   <string name="description_input_product_part2">Merci de choisir comment procéder :</string>
   <string name="description_input_product_option1">Créer un nouveau produit et utiliser l\'entrée comme nom</string>
   <string name="description_input_product_option2">Créer un produit et utiliser l\'entrée en tant que code-barres</string>
   <string name="description_input_product_option3">Ajouter en tant que code-barres à un produit existant</string>
-  <string name="description_input_product_amount">Stock min., Consommation rapide, Facteur, Tarage</string>
-  <string name="description_input_product_default_location">Emplacement, Magasin</string>
-  <string name="description_input_product_due_date">Type, Date par défaut (après ouverture, congélation, décongélation)</string>
-  <string name="description_input_product_optional_properties">État, Produit parent, Description, Groupe de produits, Énergie, Image</string>
-  <string name="description_input_product_quantity_unit">Stock, Format à l\'achat par défaut</string>
   <!-- Context: Clear shopping list -->
   <string name="description_clear_shopping_list_option1">Ne supprimer que les produits validés</string>
   <!-- Context: Clear shopping list -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -669,6 +669,7 @@
   <string name="property_active">Actif</string>
   <!--The same string is also in the web interface: Product edit form (maybe you can get the translation from there to prevent different translations for the same string) -->
   <string name="property_never_show">Ne jamais afficher sur l\'aperçu du stock</string>
+  <string name="property_number">Nombre</string>
   <!--The same string is also in the web interface: Product edit form (maybe you can get the translation from there to prevent different translations for the same string) -->
   <string name="property_enable_tare_weight">Activer la gestion du tarage du poids</string>
   <!--The same string is also in the web interface: Product edit form (maybe you can get the translation from there to prevent different translations for the same string) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -524,6 +524,11 @@
   <string name="description_input_product_option1">Create new product and use input as name</string>
   <string name="description_input_product_option2">Create new product and use input as barcode</string>
   <string name="description_input_product_option3">Add as barcode to existing product</string>
+  <string name="description_input_product_amount">Min. stock, Quick consume, Factor, Tare weight handling</string>
+  <string name="description_input_product_default_location">Location, Store</string>
+  <string name="description_input_product_due_date">Type, Default days (after opened, freezing, thawing)</string>
+  <string name="description_input_product_optional_properties">State, Parent product, Description, Product group, Energy, Picture</string>
+  <string name="description_input_product_quantity_unit">Stock, Purchase default</string>
   <!-- Context: Clear shopping list -->
   <string name="description_clear_shopping_list_option1">Delete only done items</string>
   <!-- Context: Clear shopping list -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -518,17 +518,17 @@
   <string name="subtitle_barcode">Barcode: %1$s</string>
   <string name="subtitle_feature_disabled">Feature disabled</string>
   <string name="subtitle_date_from_input">Date from input:\n%1$s</string>
+  <string name="subtitle_product_amount">Min. stock, Quick consume, Factor, Tare weight handling</string>
+  <string name="subtitle_product_default_location">Location, Store</string>
+  <string name="subtitle_product_due_date">Type, Default days (after opened, freezing, thawing)</string>
+  <string name="subtitle_product_optional_properties">State, Parent product, Description, Product group, Energy, Picture</string>
+  <string name="subtitle_product_quantity_unit">Stock, Purchase default</string>
 
   <string name="description_input_product_part1">Product field contains:</string>
   <string name="description_input_product_part2">Please choose how to proceed:</string>
   <string name="description_input_product_option1">Create new product and use input as name</string>
   <string name="description_input_product_option2">Create new product and use input as barcode</string>
   <string name="description_input_product_option3">Add as barcode to existing product</string>
-  <string name="description_input_product_amount">Min. stock, Quick consume, Factor, Tare weight handling</string>
-  <string name="description_input_product_default_location">Location, Store</string>
-  <string name="description_input_product_due_date">Type, Default days (after opened, freezing, thawing)</string>
-  <string name="description_input_product_optional_properties">State, Parent product, Description, Product group, Energy, Picture</string>
-  <string name="description_input_product_quantity_unit">Stock, Purchase default</string>
   <!-- Context: Clear shopping list -->
   <string name="description_clear_shopping_list_option1">Delete only done items</string>
   <!-- Context: Clear shopping list -->


### PR DESCRIPTION
Moved raw strings from edit/create product page (master_product) to strings.xml to allow translations.
Fixes #488 