### PR TITLE
Fix recipe methods

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/RecipesViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/RecipesViewModel.java
@@ -249,7 +249,7 @@ public class RecipesViewModel extends BaseViewModel {
   }
 
   public void consumeRecipe(int recipeId) {
-    dlHelper.get(
+    dlHelper.post(
         grocyApi.consumeRecipe(recipeId),
         response -> downloadData(),
         this::showErrorMessage
@@ -257,7 +257,7 @@ public class RecipesViewModel extends BaseViewModel {
   }
 
   public void addNotFulfilledProductsToCartForRecipe(int recipeId) {
-    dlHelper.get(
+    dlHelper.post(
         grocyApi.addNotFulfilledProductsToCartForRecipe(recipeId),
         response -> downloadData(),
         this::showErrorMessage


### PR DESCRIPTION
according to the api reference [0], those two methods are called with POST. At the moment, the app log shows HTTP error 405 when consuming recipes. I did not test the changes yet.

[0] https://demo.grocy.info/api#/Recipes/post_recipes__recipeId__consume