### PR TITLE
Do not check whether the inventory already has the correct value.

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/model/FormDataInventory.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/model/FormDataInventory.java
@@ -730,20 +730,6 @@ public class FormDataInventory {
       ));
       return false;
     }
-    if (!isTareWeightEnabled()&& NumUtil.isStringDouble(amountLive.getValue())
-        && Double.parseDouble(amountLive.getValue()) == productDetails.getStockAmount()) {
-      amountErrorLive.setValue(application.getString(R.string.error_amount_equal_stock,
-          NumUtil.trimAmount(productDetails.getStockAmount(), maxDecimalPlacesAmount)));
-      return false;
-    }
-    if (isTareWeightEnabled() && NumUtil.isStringDouble(amountLive.getValue())
-        && Double.parseDouble(amountLive.getValue()) == productDetails.getStockAmount()
-        + productDetails.getProduct().getTareWeightDouble()) {
-      amountErrorLive.setValue(application.getString(R.string.error_amount_equal_stock,
-          NumUtil.trimAmount(productDetails.getStockAmount()
-              + productDetails.getProduct().getTareWeightDouble(), maxDecimalPlacesAmount)));
-      return false;
-    }
     if (!isTareWeightEnabled() && Double.parseDouble(amountLive.getValue()) < 0) {
       amountErrorLive.setValue(application.getString(
           R.string.error_bounds_min, String.valueOf(0)


### PR DESCRIPTION
Addresses issue #605 

The `error_amount_equal_stock` string could be removed from all translation files too, if needed.