### PR TITLE
Changed debug build variant config to allow installation of debug version alongside release variant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,9 @@ android {
             }
             debuggable false
         }
+        debug {
+            applicationIdSuffix '.debug'
+        }
     }
 
     bundle {


### PR DESCRIPTION
By adding an `applicationIdSuffix` in the config for debug build variant it is appended to the application package name allowing it to be installed as a separate application from the release version. In this way it is possible to debug during development (even using a separate test server) without impacting the release version (connected to the regular server for everyday use)