### PR TITLE
Fix QU Conversion on Purchase

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/util/QuantityUnitConversionUtil.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/util/QuantityUnitConversionUtil.java
@@ -46,6 +46,17 @@ public class QuantityUnitConversionUtil {
     HashMap<QuantityUnit, Double> unitFactors = new HashMap<>();
     for (QuantityUnitConversion conversion : unitConversions) {
       if (conversion.getProductIdInt() != product.getId()) continue;
+
+      // We need this check because unitConversions list can contain multiple entry for the same "to" QU.
+      //
+      // Example:
+      // Bottle -> mL | 100.0
+      // mL -> Bottle | 0.01
+      // Bottle -> Bottle | 1.0
+      //
+      // Without this check the output map will contain 0.01 for Bottle key
+      if (conversion.getFromQuId() != product.getQuIdStockInt()) continue;
+
       QuantityUnit unit = quantityUnitHashMap.get(conversion.getToQuId());
       if (unit == null || unitFactors.containsKey(unit)) continue;
       unitFactors.put(unit, conversion.getFactor());


### PR DESCRIPTION
Based on my understanding, this function should return a map to convert from the product "stock QU" to any QU.  If that's the case, the code has some issue if we have >1 conversions to the same QU from different QU.
Example:
| from | to | factor|
|--|--|--|
| bottle | mL | 100.0|
| mL | Bottle | 0.01 |
| Bottle | Bottle | 1.0 |

The current code will create a map with 0.01 instead of 1.0 as the value for "Bottle" key

I only tested this for purchase and consume flow on my server (v4.0.0).
Should be related to #745