### PR TITLE
Only disable move-on-open switch if no default consume location selected

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/form/FormDataMasterProductCatLocation.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/form/FormDataMasterProductCatLocation.java
@@ -135,8 +135,7 @@ public class FormDataMasterProductCatLocation {
   }
 
   public void disableMoveOnOpenIfNecessary() {
-    moveOnOpenDisabledLive.setValue(locationLive.getValue() == locationConsumeLive.getValue()
-        || locationConsumeLive.getValue() == null);
+    moveOnOpenDisabledLive.setValue(locationConsumeLive.getValue() == null);
     assert moveOnOpenDisabledLive.getValue() != null;
     if (moveOnOpenDisabledLive.getValue()) {
       moveOnOpenLive.setValue(false);


### PR DESCRIPTION
The server UI doesn't disable the checkbox. The setting can be useful even with the default location being the same as the default consume location: The specific item being opened might not be in the default consume location already, and the user might want it to be moved there in that case.