### PR TITLE
Take into account exif rotation information when scaling images.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,6 +127,8 @@ dependencies {
     // ZXing for barcode scanning
     implementation libs.zxing.core
     implementation libs.zxing.android.embedded
+    // For image rotation
+    implementation libs.exifinterface
     // https://github.com/journeyapps/zxing-android-embedded#option-2-desugaring-advanced
     // prevents bug https://github.com/patzly/grocy-android/issues/425
     coreLibraryDesugaring libs.desugar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ work = "2.10.0"
 zxing-core = "3.3.0"
 zxing-android-embedded = "4.3.0"
 desugar = "2.1.4"
+exifinterface = "1.3.7"
 
 [libraries]
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
@@ -67,6 +68,7 @@ zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", ve
 # https://github.com/journeyapps/zxing-android-embedded#option-2-desugaring-advanced
 # prevents bug https://github.com/patzly/grocy-android/issues/425
 desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
+exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exifinterface" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Thanks for this app! I've started using it recently and it's been great.

The only issue I've run into so far is that when I try to upload photos from my camera, they are always rotated by 90 degrees. Looking at #877, this seems to happen for other users as well.

I looked into the code and it seems to happen during image scaling, because some photos are stored rotated with orientation information in the exif metadata. Here's an attempt to take that rotation information into account and optionally rotate during scaling.

Smoke tested on a Pixel 7.