### PR TITLE
Substantially improve product searches by showing top 30 items only

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/adapter/MatchProductsArrayAdapter.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/adapter/MatchProductsArrayAdapter.java
@@ -94,11 +94,11 @@ public class MatchProductsArrayAdapter extends ArrayAdapter<Product> {
         return new FilterResults();
       }
 
-      // Initialize suggestion list with max. capacity; growing is expensive.
-      ArrayList<Product> suggestions = new ArrayList<>(tempItems.keySet().size());
-      List<ExtractedResult> results = FuzzySearch.extractSorted(
+      ArrayList<Product> suggestions = new ArrayList<>(30);
+      List<ExtractedResult> results = FuzzySearch.extractTop(
           constraint.toString().toLowerCase(),
           tempItems.keySet(),
+          30,
           50
       );
       for (ExtractedResult result : results) {

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/ChooseProductViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/ChooseProductViewModel.java
@@ -155,7 +155,11 @@ public class ChooseProductViewModel extends BaseViewModel {
 
     if (productName == null || productName.isEmpty()) {
       SortUtil.sortProductsByName(products, true);
-      displayedItemsLive.setValue(products);
+      if (products.size() > 30) {
+        displayedItemsLive.setValue(products.subList(0, 30));
+      } else {
+        displayedItemsLive.setValue(products);
+      }
       createProductTextLive.setValue(getString(R.string.msg_create_new_product));
       if (pendingProductsActive) {
         createPendingProductTextLive.setValue(
@@ -174,11 +178,12 @@ public class ChooseProductViewModel extends BaseViewModel {
     ArrayList<Product> allProducts = new ArrayList<>();
     allProducts.addAll(products);
     allProducts.addAll(pendingProducts);
-    ArrayList<Product> suggestions = new ArrayList<>(allProducts.size());
-    List<BoundExtractedResult<Product>> results = FuzzySearch.extractSorted(
+    ArrayList<Product> suggestions = new ArrayList<>(30);
+    List<BoundExtractedResult<Product>> results = FuzzySearch.extractTop(
             productName.toLowerCase(),
             allProducts,
             Product::getName,
+            30,
             20
     );
     for (BoundExtractedResult<Product> result : results) {

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/MasterObjectListViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/MasterObjectListViewModel.java
@@ -176,14 +176,15 @@ public class MasterObjectListViewModel extends BaseViewModel {
     ArrayList<Object> searchedItems;
     if (search != null && !search.isEmpty()) {
 
-      ArrayList<Object> searchResultsFuzzy = new ArrayList<>(objects.size());
-      List results = FuzzySearch.extractSorted(
+      ArrayList<Object> searchResultsFuzzy = new ArrayList<>(30);
+      List results = FuzzySearch.extractTop(
           search,
           objects,
           item -> {
             String name = ObjectUtil.getObjectName(item, entity);
             return name != null ? name.toLowerCase() : "";
           },
+          30,
           70
       );
       for (Object result : results) {

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/StockOverviewViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/StockOverviewViewModel.java
@@ -640,12 +640,12 @@ public class StockOverviewViewModel extends BaseViewModel {
   public void updateSearchInput(String input) {
     this.searchInput = input.toLowerCase();
 
-    // Initialize suggestion list with max. capacity; growing is expensive.
-    searchResultsFuzzy = new ArrayList<>(products.size());
-    List<BoundExtractedResult<Product>> results = FuzzySearch.extractSorted(
+    searchResultsFuzzy = new ArrayList<>(30);
+    List<BoundExtractedResult<Product>> results = FuzzySearch.extractTop(
         this.searchInput,
         products,
         item -> item.getName().toLowerCase(),
+        30,
         70
     );
     for (BoundExtractedResult<Product> result : results) {


### PR DESCRIPTION
After growing inventory for many years, product searches started to be really slow!

That was especially noticeable on older HW where it would take ~3 seconds to display the list of products (in the ProductChooser initially as well as during filtering by adding characters to the search query).

This change restricts all fuzz searches to top 30 items which should be more than enough.

Additionally it also restricts the initial list of products in ProductChooser to 30 - it is unlikely that anyone would scroll manually through ~2000 products to pick one after scanning a new bar code. We could not display a list at all and wait for at least a single character in the Product name field but showing first 30 is probably a bit nicer. While mostly useless, it still at least shows the user that search results will be displayed there.

This change does not affect initial list of Master data. I think it is expected to see all products there even without a search. Of course some kind of live pagination would be helpful but I think it is probably used very rarely anyway and waiting there is not a major problem.