### PR TITLE
Make confirmation bottom sheets working when animations are disabled

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/fragment/bottomSheetDialog/QuickModeConfirmBottomSheet.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/fragment/bottomSheetDialog/QuickModeConfirmBottomSheet.java
@@ -20,9 +20,6 @@
 
 package xyz.zedler.patrick.grocy.fragment.bottomSheetDialog;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
-import android.animation.ValueAnimator;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -35,6 +32,7 @@ import xyz.zedler.patrick.grocy.Constants.ARGUMENT;
 import xyz.zedler.patrick.grocy.activity.MainActivity;
 import xyz.zedler.patrick.grocy.databinding.FragmentBottomsheetScanModeConfirmBinding;
 import xyz.zedler.patrick.grocy.util.UiUtil;
+import xyz.zedler.patrick.grocy.util.ValueAnimatorUtil;
 
 public class QuickModeConfirmBottomSheet extends BaseBottomSheetDialogFragment {
 
@@ -43,7 +41,7 @@ public class QuickModeConfirmBottomSheet extends BaseBottomSheetDialogFragment {
 
   private FragmentBottomsheetScanModeConfirmBinding binding;
   private MainActivity activity;
-  private ValueAnimator confirmProgressAnimator;
+  private ValueAnimatorUtil confirmProgressAnimator;
   private boolean openAction = false;
   private boolean progressStopped = false;
 
@@ -163,15 +161,15 @@ public class QuickModeConfirmBottomSheet extends BaseBottomSheetDialogFragment {
       confirmProgressAnimator.cancel();
       confirmProgressAnimator = null;
     }
-    confirmProgressAnimator = ValueAnimator.ofInt(startValue, binding.progressTimeout.getMax());
+    confirmProgressAnimator = ValueAnimatorUtil.ofInt(startValue, binding.progressTimeout.getMax());
     confirmProgressAnimator.setDuration((long) CONFIRMATION_DURATION
         * (binding.progressTimeout.getMax() - startValue) / binding.progressTimeout.getMax());
     confirmProgressAnimator.addUpdateListener(
         animation -> binding.progressTimeout.setProgress((Integer) animation.getAnimatedValue())
     );
-    confirmProgressAnimator.addListener(new AnimatorListenerAdapter() {
+    confirmProgressAnimator.addListener(new ValueAnimatorUtil.AnimatorListenerAdapter() {
       @Override
-      public void onAnimationEnd(Animator animation) {
+      public void onAnimationEnd(ValueAnimatorUtil animation) {
         if (binding.progressTimeout.getProgress() != binding.progressTimeout.getMax()) {
           return;
         }

--- a/app/src/main/java/xyz/zedler/patrick/grocy/fragment/bottomSheetDialog/TaskEntryBottomSheet.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/fragment/bottomSheetDialog/TaskEntryBottomSheet.java
@@ -44,6 +44,7 @@ import xyz.zedler.patrick.grocy.model.Task;
 import xyz.zedler.patrick.grocy.util.DateUtil;
 import xyz.zedler.patrick.grocy.util.ResUtil;
 import xyz.zedler.patrick.grocy.util.UiUtil;
+import xyz.zedler.patrick.grocy.util.ValueAnimatorUtil;
 import xyz.zedler.patrick.grocy.util.ViewUtil;
 
 public class TaskEntryBottomSheet extends BaseBottomSheetDialogFragment {
@@ -54,7 +55,7 @@ public class TaskEntryBottomSheet extends BaseBottomSheetDialogFragment {
   private MainActivity activity;
   private FragmentBottomsheetTaskEntryBinding binding;
   private ProgressBar progressConfirm;
-  private ValueAnimator confirmProgressAnimator;
+  private ValueAnimatorUtil confirmProgressAnimator;
   private Task task;
 
   @Override
@@ -164,15 +165,15 @@ public class TaskEntryBottomSheet extends BaseBottomSheetDialogFragment {
       confirmProgressAnimator.cancel();
       confirmProgressAnimator = null;
     }
-    confirmProgressAnimator = ValueAnimator.ofInt(startValue, progressConfirm.getMax());
+    confirmProgressAnimator = ValueAnimatorUtil.ofInt(startValue, progressConfirm.getMax());
     confirmProgressAnimator.setDuration((long) DELETE_CONFIRMATION_DURATION
         * (progressConfirm.getMax() - startValue) / progressConfirm.getMax());
     confirmProgressAnimator.addUpdateListener(
         animation -> progressConfirm.setProgress((Integer) animation.getAnimatedValue())
     );
-    confirmProgressAnimator.addListener(new AnimatorListenerAdapter() {
+    confirmProgressAnimator.addListener(new ValueAnimatorUtil.AnimatorListenerAdapter() {
       @Override
-      public void onAnimationEnd(Animator animation) {
+      public void onAnimationEnd(ValueAnimatorUtil animation) {
         int currentProgress = progressConfirm.getProgress();
         if (currentProgress == progressConfirm.getMax()) {
           TransitionManager.beginDelayedTransition((ViewGroup) requireView());
@@ -182,16 +183,16 @@ public class TaskEntryBottomSheet extends BaseBottomSheetDialogFragment {
           dismiss();
           return;
         }
-        confirmProgressAnimator = ValueAnimator.ofInt(currentProgress, 0);
+        confirmProgressAnimator = ValueAnimatorUtil.ofInt(currentProgress, 0);
         confirmProgressAnimator.setDuration((long) (DELETE_CONFIRMATION_DURATION / 2)
             * currentProgress / progressConfirm.getMax());
         confirmProgressAnimator.setInterpolator(new FastOutSlowInInterpolator());
         confirmProgressAnimator.addUpdateListener(
             anim -> progressConfirm.setProgress((Integer) anim.getAnimatedValue())
         );
-        confirmProgressAnimator.addListener(new AnimatorListenerAdapter() {
+        confirmProgressAnimator.addListener(new ValueAnimatorUtil.AnimatorListenerAdapter() {
           @Override
-          public void onAnimationEnd(Animator animation) {
+          public void onAnimationEnd(ValueAnimatorUtil animation) {
             TransitionManager.beginDelayedTransition((ViewGroup) requireView());
             progressConfirm.setVisibility(View.GONE);
           }

--- a/app/src/main/java/xyz/zedler/patrick/grocy/util/ValueAnimatorUtil.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/util/ValueAnimatorUtil.java
@@ -1,0 +1,163 @@
+/*
+ * This file is part of Grocy Android.
+ *
+ * Grocy Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grocy Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grocy Android. If not, see http://www.gnu.org/licenses/.
+ *
+ * Copyright (c) 2020-2024 by Patrick Zedler and Dominic Zedler
+ * Copyright (c) 2024-2025 by Patrick Zedler
+ */
+
+package xyz.zedler.patrick.grocy.util;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.view.animation.Interpolator;
+import android.view.animation.LinearInterpolator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ValueAnimatorUtil {
+
+    private long duration = 300; // Default duration
+    private long startTime;
+    private boolean running = false;
+    private boolean isIntAnimation = false;
+
+    private float startFloatValue;
+    private float endFloatValue;
+    private float currentFloatValue;
+
+    private final List<AnimatorUpdateListener> updateListeners = new ArrayList<>();
+    private final List<AnimatorListener> listeners = new ArrayList<>();
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+
+    private Interpolator interpolator = new LinearInterpolator(); // Default interpolator
+
+    @SuppressWarnings("unused")
+    public static ValueAnimatorUtil ofInt(int start, int end) {
+        ValueAnimatorUtil animator = new ValueAnimatorUtil();
+        animator.startFloatValue = start;
+        animator.endFloatValue = end;
+        animator.isIntAnimation = true;
+        return animator;
+    }
+
+    @SuppressWarnings("unused")
+    public static ValueAnimatorUtil ofFloat(float start, float end) {
+        ValueAnimatorUtil animator = new ValueAnimatorUtil();
+        animator.startFloatValue = start;
+        animator.endFloatValue = end;
+        animator.isIntAnimation = false;
+        return animator;
+    }
+
+    public void setDuration(long duration) {
+        this.duration = duration;
+    }
+
+    public void addUpdateListener(AnimatorUpdateListener listener) {
+        updateListeners.add(listener);
+    }
+
+    public void addListener(AnimatorListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeAllListeners() {
+        updateListeners.clear();
+        listeners.clear();
+    }
+
+    public void setInterpolator(Interpolator interpolator) {
+        this.interpolator = interpolator;
+    }
+
+    public void start() {
+        if (running) return;
+
+        running = true;
+        startTime = System.currentTimeMillis();
+
+        for (AnimatorListener listener : listeners) {
+            listener.onAnimationStart(this);
+        }
+
+        handler.post(animationRunnable);
+    }
+
+    public void cancel() {
+        if (!running) return;
+
+        running = false;
+        handler.removeCallbacks(animationRunnable);
+
+        for (AnimatorListener listener : listeners) {
+            listener.onAnimationCancel(this);
+        }
+    }
+
+    private final Runnable animationRunnable = new Runnable() {
+        @Override
+        public void run() {
+            long elapsed = System.currentTimeMillis() - startTime;
+            float fraction = Math.min(1f, (float) elapsed / duration);
+            fraction = interpolator.getInterpolation(fraction);
+
+            currentFloatValue = startFloatValue + fraction * (endFloatValue - startFloatValue);
+
+            for (AnimatorUpdateListener listener : updateListeners) {
+                listener.onAnimationUpdate(ValueAnimatorUtil.this);
+            }
+
+            if (fraction < 1f) {
+                handler.postDelayed(this, 16);
+            } else {
+                running = false;
+                for (AnimatorListener listener : listeners) {
+                    listener.onAnimationEnd(ValueAnimatorUtil.this);
+                }
+            }
+        }
+    };
+
+    public Object getAnimatedValue() {
+        if (isIntAnimation) {
+            return Math.round(currentFloatValue);
+        }
+        return currentFloatValue;
+    }
+
+    public interface AnimatorUpdateListener {
+        void onAnimationUpdate(ValueAnimatorUtil animation);
+    }
+
+    public interface AnimatorListener {
+        void onAnimationStart(ValueAnimatorUtil animation);
+        void onAnimationEnd(ValueAnimatorUtil animation);
+        void onAnimationCancel(ValueAnimatorUtil animation);
+    }
+
+    public abstract static class AnimatorListenerAdapter implements AnimatorListener {
+        @Override
+        public void onAnimationStart(ValueAnimatorUtil animation) {}
+
+        @Override
+        public void onAnimationEnd(ValueAnimatorUtil animation) {}
+
+        @Override
+        public void onAnimationCancel(ValueAnimatorUtil animation) {}
+    }
+}

--- a/app/src/main/java/xyz/zedler/patrick/grocy/util/ViewUtil.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/util/ViewUtil.java
@@ -358,7 +358,7 @@ public class ViewUtil {
 
   public static class TouchProgressBarUtil {
     private final ProgressBar progressConfirm;
-    private ValueAnimator confirmProgressAnimator;
+    private ValueAnimatorUtil confirmProgressAnimator;
     private final OnConfirmedListener onConfirmedListener;
     private final int delayMilliseconds;
 
@@ -412,15 +412,15 @@ public class ViewUtil {
         confirmProgressAnimator.cancel();
         confirmProgressAnimator = null;
       }
-      confirmProgressAnimator = ValueAnimator.ofInt(startValue, progressConfirm.getMax());
+      confirmProgressAnimator = ValueAnimatorUtil.ofInt(startValue, progressConfirm.getMax());
       confirmProgressAnimator.setDuration((long) delayMilliseconds
           * (progressConfirm.getMax() - startValue) / progressConfirm.getMax());
       confirmProgressAnimator.addUpdateListener(
           animation -> progressConfirm.setProgress((Integer) animation.getAnimatedValue())
       );
-      confirmProgressAnimator.addListener(new AnimatorListenerAdapter() {
+      confirmProgressAnimator.addListener(new ValueAnimatorUtil.AnimatorListenerAdapter() {
         @Override
-        public void onAnimationEnd(Animator animation) {
+        public void onAnimationEnd(ValueAnimatorUtil animation) {
           int currentProgress = progressConfirm.getProgress();
           if (currentProgress == progressConfirm.getMax()) {
             TransitionManager.beginDelayedTransition((ViewGroup) progressConfirm.getParent());
@@ -429,16 +429,16 @@ public class ViewUtil {
             onConfirmedListener.onConfirmed(objectOptional);
             return;
           }
-          confirmProgressAnimator = ValueAnimator.ofInt(currentProgress, 0);
+          confirmProgressAnimator = ValueAnimatorUtil.ofInt(currentProgress, 0);
           confirmProgressAnimator.setDuration((long) (delayMilliseconds / 2)
               * currentProgress / progressConfirm.getMax());
           confirmProgressAnimator.setInterpolator(new FastOutSlowInInterpolator());
           confirmProgressAnimator.addUpdateListener(
               anim -> progressConfirm.setProgress((Integer) anim.getAnimatedValue())
           );
-          confirmProgressAnimator.addListener(new AnimatorListenerAdapter() {
+          confirmProgressAnimator.addListener(new ValueAnimatorUtil.AnimatorListenerAdapter() {
             @Override
-            public void onAnimationEnd(Animator animation) {
+            public void onAnimationEnd(ValueAnimatorUtil animation) {
               TransitionManager.beginDelayedTransition((ViewGroup) progressConfirm.getParent());
               progressConfirm.setVisibility(View.GONE);
             }


### PR DESCRIPTION
When animations are disabled system-wide (or disabled automatically when battery is low on Samsung devices), bottom sheets with 3-second timeout are skipped and their action is done immediately.

This is especially problematic in Purchase flow when one needs to update the number of  items purchased.

This PR fixes it by introducing a ValueAnimatorUtil - a class implementing a subset of ValueAnimator functionality. The implementation is not affected by system-wide animation scaling, therefore confirmation bottom sheets will be shown in such cases too, with their progress bars animating.