### PR TITLE
Add support for grocy server version 4.5.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId "xyz.zedler.patrick.grocy"
         minSdk 21
         targetSdk 35
-        versionCode 61
-        versionName "3.8.1"
+        versionCode 62
+        versionName "3.8.2"
         resourceConfigurations += ['ca', 'cs', 'de', 'en', 'es', 'et', 'fr', 'hu', 'it', 'iw', 'ja',
                                    'nb', 'nl', 'pl', 'pt-rBR', 'pt-rPT', 'ru', 'sk', 'sv', 'uk',
                                    'zh-rCN', 'zh-rTW']

--- a/app/src/main/res/raw/changelog.txt
+++ b/app/src/main/res/raw/changelog.txt
@@ -1,3 +1,7 @@
+## 3.8.2
+
+- New: Compatibility for server version 4.5.0
+
 ## 3.8.1
 
 - New: Compatibility for server version 4.4.2

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -31,6 +31,7 @@
     <item>4.4.0</item>
     <item>4.4.1</item>
     <item>4.4.2</item>
+    <item>4.5.0</item>
   </string-array>
 
 </resources>


### PR DESCRIPTION
This PR adds support for grocy server version 4.5.0. I've successfully tested these changes with my own self-hosted instance.