### PR TITLE
Use quantityUnitPrice for last & avg price

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/fragment/bottomSheetDialog/ProductOverviewBottomSheet.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/fragment/bottomSheetDialog/ProductOverviewBottomSheet.java
@@ -89,6 +89,8 @@ public class ProductOverviewBottomSheet extends BaseBottomSheetDialogFragment {
   private Product product;
   private QuantityUnit quantityUnitStock;
   private QuantityUnit quantityUnitPurchase;
+  private QuantityUnit quantityUnitConsume;
+  private QuantityUnit quantityUnitPrice;
   private PluralUtil pluralUtil;
   private Location location;
   private AlertDialog dialogDelete;
@@ -139,12 +141,16 @@ public class ProductOverviewBottomSheet extends BaseBottomSheetDialogFragment {
       stockItem = args.getStockItem();
       quantityUnitStock = args.getQuantityUnitStock();
       quantityUnitPurchase = args.getQuantityUnitPurchase();
+      quantityUnitConsume = args.getQuantityUnitConsume();
+      quantityUnitPrice = args.getQuantityUnitPrice();
       location = args.getLocation();
       product = stockItem.getProduct();
     } else if (args.getProduct() != null) {
       product = args.getProduct();
       quantityUnitStock = args.getQuantityUnitStock();
       quantityUnitPurchase = args.getQuantityUnitPurchase();
+      quantityUnitConsume = args.getQuantityUnitConsume();
+      quantityUnitPrice = args.getQuantityUnitPrice();
       location = args.getLocation();
     }
 
@@ -376,6 +382,8 @@ public class ProductOverviewBottomSheet extends BaseBottomSheetDialogFragment {
     if (hasDetails()) {
       quantityUnitStock = productDetails.getQuantityUnitStock();
       quantityUnitPurchase = productDetails.getQuantityUnitPurchase();
+      quantityUnitConsume = productDetails.getQuantityUnitConsume();
+      quantityUnitPrice = productDetails.getQuantityUnitPrice();
     }
 
     // AMOUNT
@@ -468,7 +476,7 @@ public class ProductOverviewBottomSheet extends BaseBottomSheetDialogFragment {
               : null
       );
 
-      boolean quantityUnitsAreNotEqual = quantityUnitStock.getId() != quantityUnitPurchase.getId();
+      boolean quantityUnitsAreNotEqual = quantityUnitStock.getId() != quantityUnitPrice.getId();
 
       // LAST PRICE
       String lastPrice = productDetails.getLastPrice();
@@ -481,7 +489,7 @@ public class ProductOverviewBottomSheet extends BaseBottomSheetDialogFragment {
                 NumUtil.trimPrice(NumUtil.toDouble(lastPrice)
                     * productDetails.getQuFactorPriceToStock(), decimalPlacesPriceDisplay)
                     + " " + sharedPrefs.getString(Constants.PREF.CURRENCY, ""),
-                quantityUnitPurchase.getName()
+                quantityUnitPrice.getName()
             ),
             quantityUnitsAreNotEqual ? activity.getString(
                 R.string.property_price_unit_insert,
@@ -492,7 +500,7 @@ public class ProductOverviewBottomSheet extends BaseBottomSheetDialogFragment {
         );
       }
 
-      // LAST PRICE
+      // AVERAGE PRICE
       String averagePrice = productDetails.getAvgPrice();
       if (NumUtil.isStringDouble(averagePrice) && isFeatureEnabled(
           Constants.PREF.FEATURE_STOCK_PRICE_TRACKING)) {
@@ -503,7 +511,7 @@ public class ProductOverviewBottomSheet extends BaseBottomSheetDialogFragment {
                 NumUtil.trimPrice(NumUtil.toDouble(averagePrice)
                     * productDetails.getQuFactorPriceToStock(), decimalPlacesPriceDisplay)
                     + " " + sharedPrefs.getString(Constants.PREF.CURRENCY, ""),
-                quantityUnitPurchase.getName()
+                quantityUnitPrice.getName()
             ),
             quantityUnitsAreNotEqual ? activity.getString(
                 R.string.property_price_unit_insert,

--- a/app/src/main/java/xyz/zedler/patrick/grocy/model/ProductDetails.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/model/ProductDetails.java
@@ -68,6 +68,12 @@ public class ProductDetails implements Parcelable {
   @SerializedName("quantity_unit_stock")
   private final QuantityUnit quantityUnitStock;
 
+  @SerializedName("quantity_unit_consume")
+  private final QuantityUnit quantityUnitConsume;
+
+  @SerializedName("quantity_unit_price")
+  private final QuantityUnit quantityUnitPrice;
+
   @SerializedName("last_price")
   private final String lastPrice;
 
@@ -118,6 +124,8 @@ public class ProductDetails implements Parcelable {
     stockAmountOpenedAggregated = parcel.readString();
     quantityUnitPurchase = parcel.readParcelable(QuantityUnit.class.getClassLoader());
     quantityUnitStock = parcel.readParcelable(QuantityUnit.class.getClassLoader());
+    quantityUnitConsume = parcel.readParcelable(QuantityUnit.class.getClassLoader());
+    quantityUnitPrice = parcel.readParcelable(QuantityUnit.class.getClassLoader());
     lastPrice = parcel.readString();
     avgPrice = parcel.readString();
     currentPrice = parcel.readString();
@@ -145,6 +153,8 @@ public class ProductDetails implements Parcelable {
     dest.writeString(stockAmountOpenedAggregated);
     dest.writeParcelable(quantityUnitPurchase, 0);
     dest.writeParcelable(quantityUnitStock, 0);
+    dest.writeParcelable(quantityUnitConsume, 0);
+    dest.writeParcelable(quantityUnitPrice, 0);
     dest.writeString(lastPrice);
     dest.writeString(avgPrice);
     dest.writeString(currentPrice);
@@ -207,6 +217,14 @@ public class ProductDetails implements Parcelable {
 
   public QuantityUnit getQuantityUnitStock() {
     return quantityUnitStock;
+  }
+
+  public QuantityUnit getQuantityUnitConsume() {
+    return quantityUnitConsume;
+  }
+
+  public QuantityUnit getQuantityUnitPrice() {
+    return quantityUnitPrice;
   }
 
   public String getLastPrice() {

--- a/app/src/main/res/navigation/navigation_main.xml
+++ b/app/src/main/res/navigation/navigation_main.xml
@@ -225,6 +225,16 @@
       app:nullable="true"
       android:defaultValue="@null" />
     <argument
+      android:name="quantityUnitConsume"
+      app:argType="xyz.zedler.patrick.grocy.model.QuantityUnit"
+      app:nullable="true"
+      android:defaultValue="@null" />
+    <argument
+      android:name="quantityUnitPrice"
+      app:argType="xyz.zedler.patrick.grocy.model.QuantityUnit"
+      app:nullable="true"
+      android:defaultValue="@null" />
+    <argument
       android:name="product"
       app:argType="xyz.zedler.patrick.grocy.model.Product"
       app:nullable="true"


### PR DESCRIPTION

This uses the selected Price unit instead of Purchase Unit in the Product Overview and should address #807 

- add quantityUnitConsume & quantityUnitPrice
- use quantityUnitPrice instead of quantityUnitConsume when showing last price and average price in product details

This is my first pull request, so if you have suggestions for improving this, I'd be happy to apply them. :)

The screenshot is using the demo instance

<img width="1080" height="2400" alt="Screenshot_20251212_092246" src="https://github.com/user-attachments/assets/92eb3cdf-5337-49f4-8db4-bcd40d6df337" />


