### PR TITLE
Add a setting to enable or disable the use of the amount.

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/Constants.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/Constants.java
@@ -177,6 +177,7 @@ public final class Constants {
       public final static String DATE_KEYBOARD_INPUT = "date_keyboard_input";
       public final static String DATE_KEYBOARD_REVERSE = "date_keyboard_reverse";
       public final static String MESSAGE_DURATION = "message_duration";
+      public final static String BARCODE_AMOUNT = "product_barcode_amount";
     }
 
     public final static class SCANNER {
@@ -281,6 +282,7 @@ public final class Constants {
       public final static boolean DATE_KEYBOARD_INPUT = false;
       public final static boolean DATE_KEYBOARD_REVERSE = false;
       public final static int MESSAGE_DURATION = 10;
+      public final static boolean BARCODE_AMOUNT = true;
     }
 
     public final static class SCANNER {

--- a/app/src/main/java/xyz/zedler/patrick/grocy/form/FormDataPurchase.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/form/FormDataPurchase.java
@@ -876,7 +876,7 @@ public class FormDataPurchase {
     Product product = productDetailsLive.getValue().getProduct();
     Store store = storeLive.getValue();
     String note = noteLive.getValue();
-    String amount = amountLive.getValue();
+    String amount = getBarcodeAmountEnabled() ? amountLive.getValue() : "1";
     Integer quId = quantityUnitLive.getValue() != null ? quantityUnitLive.getValue().getId() : null;
 
     ProductBarcode productBarcode = new ProductBarcode();
@@ -973,6 +973,13 @@ public class FormDataPurchase {
       amountErrorLive.setValue(null);
       dueDateErrorLive.setValue(false);
     }, 50);
+  }
+
+ public boolean getBarcodeAmountEnabled() {
+    return sharedPrefs.getBoolean(
+        Constants.SETTINGS.BEHAVIOR.BARCODE_AMOUNT,
+        Constants.SETTINGS_DEFAULT.BEHAVIOR.BARCODE_AMOUNT
+     );
   }
 
   public boolean getPurchasedDateEnabled() {

--- a/app/src/main/java/xyz/zedler/patrick/grocy/fragment/SettingsCatBehaviorFragment.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/fragment/SettingsCatBehaviorFragment.java
@@ -122,6 +122,7 @@ public class SettingsCatBehaviorFragment extends BaseFragment {
       binding.switchTurnOnQuickMode.jumpDrawablesToCurrentState();
       binding.switchDateKeyboardInput.jumpDrawablesToCurrentState();
       binding.switchDateKeyboardReverse.jumpDrawablesToCurrentState();
+      binding.switchBarcodeAmount.jumpDrawablesToCurrentState();
       binding.switchOpenFoodFacts.jumpDrawablesToCurrentState();
       binding.switchSpeedUpStart.jumpDrawablesToCurrentState();
     });

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/SettingsViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/SettingsViewModel.java
@@ -373,6 +373,18 @@ public class SettingsViewModel extends BaseViewModel {
         .putBoolean(Constants.SETTINGS.BEHAVIOR.DATE_KEYBOARD_REVERSE, enabled).apply();
   }
 
+  public boolean getBarcodeAmountEnabled() {
+    return sharedPrefs.getBoolean(
+        BEHAVIOR.BARCODE_AMOUNT,
+        Constants.SETTINGS_DEFAULT.BEHAVIOR.BARCODE_AMOUNT
+    );
+  }
+
+  public void setBarcodeAmountEnabled(boolean enabled) {
+    sharedPrefs.edit()
+        .putBoolean(Constants.SETTINGS.BEHAVIOR.BARCODE_AMOUNT, enabled).apply();
+  }
+
   public boolean getKeepScreenOnRecipesEnabled() {
     return sharedPrefs.getBoolean(
             RECIPES.KEEP_SCREEN_ON,

--- a/app/src/main/res/layout/fragment_settings_cat_behavior.xml
+++ b/app/src/main/res/layout/fragment_settings_cat_behavior.xml
@@ -367,6 +367,36 @@
 
           </LinearLayout>
 
+          <LinearLayout
+            style="@style/Widget.Grocy.LinearLayout.ListItem.TwoLine.Clickable.More"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:onClick="@{v -> switchBarcodeAmount.setChecked(!switchBarcodeAmount.isChecked())}">
+
+            <ImageView
+              style="@style/Widget.Grocy.ImageView.ListItem.Icon"
+              tools:ignore="ContentDescription"
+              android:src="@drawable/ic_round_barcode" />
+
+            <LinearLayout style="@style/Widget.Grocy.LinearLayout.ListItem.TextBox.Stretch">
+
+              <TextView
+                style="@style/Widget.Grocy.TextView.ListItem.Title"
+                android:text="@string/setting_barcode_amount" />
+
+              <TextView
+                style="@style/Widget.Grocy.TextView.ListItem.Description"
+                android:text="@string/setting_barcode_amount_description" />
+
+            </LinearLayout>
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+              android:id="@+id/switch_barcode_amount"
+              style="@style/Widget.Grocy.Switch"
+              android:checked="@={viewModel.barcodeAmountEnabled}" />
+
+          </LinearLayout>
+
           <TextView
             style="@style/Widget.Grocy.TextView.Category"
             android:text="@string/category_additional_services" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1282,6 +1282,8 @@
   <string name="setting_date_keyboard_input_description">Instead of date picker wheels</string>
   <string name="setting_date_keyboard_reverse">Use reverse date format for input</string>
   <string name="setting_date_keyboard_reverse_description">DDMMYY instead of YYMMDD</string>
+  <string name="setting_barcode_amount">Use amount for barcode generation</string>
+  <string name="setting_barcode_amount_description">When creating a product as part of a purchase, the entered amount is used for barcode generation.</string>
   <string name="setting_loading_circle">Show loading circle for all requests</string>
   <string name="setting_loading_circle_description">Helpful for slow networks</string>
   <string name="setting_tor">Use Tor</string>


### PR DESCRIPTION
When a user creates a new product by scanning a barcode, the amount of the initial entry is also used for barcode generation.

This behavior is useful when the barcode represents a multi-pack. However, it can be misleading when scanning a single product while multiple individual units are present.
For example, scanning one bottle of milk while having several bottles should not imply that the barcode represents multiple units.