### PR TITLE
Remove support of TLS 1.1

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/web/RequestQueueSingleton.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/web/RequestQueueSingleton.java
@@ -152,7 +152,7 @@ public class RequestQueueSingleton {
 
     private Socket enableTLSOnSocket(Socket socket) {
       if((socket instanceof SSLSocket)) {
-        ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1.1", "TLSv1.2", "TLSv1.3"});
+        ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1.2", "TLSv1.3"});
       }
       return socket;
     }


### PR DESCRIPTION
TLS 1.1 is broken and should not be used anymore.
Also the BSI [1] recommends 1.2 and 1.3 only since years.

[1] https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=11

issue: #957