### PR TITLE
Add navigation between mealplan and recipe

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/grocy/adapter/MealPlanEntryAdapter.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/adapter/MealPlanEntryAdapter.java
@@ -89,12 +89,14 @@ public class MealPlanEntryAdapter extends
   private final int maxDecimalPlacesAmount;
   private final int decimalPlacesPriceDisplay;
   private final String currency;
+  private final MealPlanEntryAdapterListener listener;
 
   public MealPlanEntryAdapter(
       Context context,
       GrocyApi grocyApi,
       LazyHeaders grocyAuthHeaders,
-      String date
+      String date,
+      MealPlanEntryAdapterListener listener
   ) {
     SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
     this.maxDecimalPlacesAmount = sharedPrefs.getInt(
@@ -120,6 +122,7 @@ public class MealPlanEntryAdapter extends
     this.grocyApi = grocyApi;
     this.grocyAuthHeaders = grocyAuthHeaders;
     this.groupedListItems = new ArrayList<>();
+    this.listener = listener;
   }
 
   static ArrayList<GroupedListItem> getGroupedListItems(
@@ -288,6 +291,7 @@ public class MealPlanEntryAdapter extends
           return;
         }
         binding.title.setText(recipe.getName());
+        binding.container.setOnClickListener(v -> listener.onItemRowClicked(recipe));
 
         if (activeFields.contains(MealPlanViewModel.FIELD_AMOUNT)) {
           double servings = NumUtil.isStringDouble(entry.getRecipeServings()) ? Double.parseDouble(
@@ -855,6 +859,11 @@ public class MealPlanEntryAdapter extends
     public void clearView(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder) {
       super.clearView(recyclerView, viewHolder);
     }
+  }
+
+  public interface MealPlanEntryAdapterListener {
+
+    void onItemRowClicked(Recipe recipe);
   }
 
 }

--- a/app/src/main/java/xyz/zedler/patrick/grocy/fragment/MealPlanPagingFragment.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/fragment/MealPlanPagingFragment.java
@@ -30,12 +30,15 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import java.time.LocalDate;
+import xyz.zedler.patrick.grocy.activity.MainActivity;
 import xyz.zedler.patrick.grocy.adapter.MealPlanEntryAdapter;
+import xyz.zedler.patrick.grocy.adapter.MealPlanEntryAdapter.MealPlanEntryAdapterListener;
 import xyz.zedler.patrick.grocy.adapter.MealPlanEntryAdapter.SimpleItemTouchHelperCallback;
 import xyz.zedler.patrick.grocy.databinding.FragmentMealPlanPagingBinding;
+import xyz.zedler.patrick.grocy.model.Recipe;
 import xyz.zedler.patrick.grocy.viewmodel.MealPlanViewModel;
 
-public class MealPlanPagingFragment extends Fragment {
+public class MealPlanPagingFragment extends Fragment implements MealPlanEntryAdapterListener {
 
   private static final String ARG_DATE = "date";
   private LocalDate date;
@@ -79,7 +82,8 @@ public class MealPlanPagingFragment extends Fragment {
         requireContext(),
         viewModel.getGrocyApi(),
         viewModel.getGrocyAuthHeaders(),
-        date.format(viewModel.getDateFormatter())
+        date.format(viewModel.getDateFormatter()),
+        this
     );
     binding.recycler.setAdapter(adapter);
 
@@ -105,5 +109,11 @@ public class MealPlanPagingFragment extends Fragment {
       }
     });
   }
-}
 
+  @Override
+  public void onItemRowClicked(Recipe recipe) {
+    ((MainActivity) requireActivity()).navUtil.navigate(
+        MealPlanFragmentDirections.actionMealPlanFragmentToRecipeFragment(recipe.getId())
+    );
+  }
+}

--- a/app/src/main/res/layout/row_meal_plan_entry.xml
+++ b/app/src/main/res/layout/row_meal_plan_entry.xml
@@ -37,6 +37,7 @@
     android:layout_marginStart="32dp">
 
     <LinearLayout
+      android:id="@+id/container"
       android:layout_height="wrap_content"
       android:layout_width="match_parent"
       android:orientation="horizontal"

--- a/app/src/main/res/navigation/navigation_main.xml
+++ b/app/src/main/res/navigation/navigation_main.xml
@@ -1223,6 +1223,9 @@
     <deepLink
       android:id="@+id/deepLink20"
       app:uri="@string/deep_link_mealPlanFragment" />
+    <action
+      android:id="@+id/action_mealPlanFragment_to_recipeFragment"
+      app:destination="@id/recipeFragment" />
   </fragment>
   <dialog
     android:id="@+id/textBottomSheetDialogFragment"


### PR DESCRIPTION
Small PR adding a link between the meal plan screen and the recipe screen.

Clicking on a recipe on the meal plan screen now open the associated recipe screen.

Fix #893 