### PR TITLE
Feature: Stock spending report

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,4 +130,5 @@ dependencies {
     // https://github.com/journeyapps/zxing-android-embedded#option-2-desugaring-advanced
     // prevents bug https://github.com/patzly/grocy-android/issues/425
     coreLibraryDesugaring(libs.desugar)
+    implementation("com.github.AppDevNext.AndroidChart:chartLib:5.2.4")
 }

--- a/app/src/main/java/xyz/zedler/patrick/grocy/adapter/SpendingItemAdapter.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/adapter/SpendingItemAdapter.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Grocy Android.
+ *
+ * Grocy Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grocy Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grocy Android. If not, see http://www.gnu.org/licenses/.
+ *
+ * Copyright (c) 2020-2024 by Patrick Zedler and Dominic Zedler
+ * Copyright (c) 2024-2026 by Patrick Zedler
+ */
+
+package xyz.zedler.patrick.grocy.adapter;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+import java.util.List;
+import xyz.zedler.patrick.grocy.R;
+import xyz.zedler.patrick.grocy.viewmodel.StockReportSpendingsViewModel.SpendingItem;
+
+public class SpendingItemAdapter
+    extends RecyclerView.Adapter<SpendingItemAdapter.ViewHolder> {
+
+  private final List<SpendingItem> items;
+  private final Formatter formatter;
+
+  public interface Formatter {
+    String format(double amount);
+  }
+
+  public SpendingItemAdapter(List<SpendingItem> items, Formatter formatter) {
+    this.items = items;
+    this.formatter = formatter;
+  }
+
+  @NonNull
+  @Override
+  public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+    View view = LayoutInflater.from(parent.getContext())
+        .inflate(R.layout.row_spending_item, parent, false);
+    return new ViewHolder(view);
+  }
+
+  @Override
+  public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+    SpendingItem item = items.get(position);
+    holder.textName.setText(item.name);
+    holder.textAmount.setText(formatter.format(item.total));
+  }
+
+  @Override
+  public int getItemCount() {
+    return items.size();
+  }
+
+  public static class ViewHolder extends RecyclerView.ViewHolder {
+    final TextView textName;
+    final TextView textAmount;
+
+    public ViewHolder(@NonNull View itemView) {
+      super(itemView);
+      textName = itemView.findViewById(R.id.text_name);
+      textAmount = itemView.findViewById(R.id.text_amount);
+    }
+  }
+}

--- a/app/src/main/java/xyz/zedler/patrick/grocy/api/GrocyApi.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/api/GrocyApi.java
@@ -522,4 +522,17 @@ public class GrocyApi {
     return getProductPicture(filename)
         + "?force_serve_as=picture&best_fit_height=800&best_fit_width=1280";
   }
+
+  public String getPurchaseStockLog(String startDate, String endDate) {
+    StringBuilder url = new StringBuilder(getUrl("/objects/stock_log"));
+    url.append("?query%5B%5D=transaction_type%3Dpurchase");
+    url.append("&query%5B%5D=undone%3D0");
+    if (startDate != null && !startDate.isEmpty()) {
+      url.append("&query%5B%5D=purchased_date%3E%3D").append(startDate);
+    }
+    if (endDate != null && !endDate.isEmpty()) {
+      url.append("&query%5B%5D=purchased_date%3C%3D").append(endDate);
+    }
+    return url.toString();
+  }
 }

--- a/app/src/main/java/xyz/zedler/patrick/grocy/fragment/StockOverviewFragment.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/fragment/StockOverviewFragment.java
@@ -355,6 +355,11 @@ public class StockOverviewFragment extends BaseFragment implements
           StockOverviewFragmentDirections.actionStockOverviewFragmentToStockEntriesFragment()
       );
       return true;
+    } else if (item.getItemId() == R.id.action_stock_report_spendings) {
+      activity.navUtil.navigate(
+          StockOverviewFragmentDirections.actionStockOverviewFragmentToStockReportSpendingsFragment()
+      );
+      return true;
     }
     return false;
   }

--- a/app/src/main/java/xyz/zedler/patrick/grocy/fragment/StockReportSpendingsFragment.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/fragment/StockReportSpendingsFragment.java
@@ -1,0 +1,372 @@
+/*
+ * This file is part of Grocy Android.
+ *
+ * Grocy Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grocy Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grocy Android. If not, see http://www.gnu.org/licenses/.
+ *
+ * Copyright (c) 2020-2024 by Patrick Zedler and Dominic Zedler
+ * Copyright (c) 2024-2026 by Patrick Zedler
+ */
+
+package xyz.zedler.patrick.grocy.fragment;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import info.appdev.charting.animation.Easing;
+import info.appdev.charting.charts.PieChart;
+import info.appdev.charting.data.PieData;
+import info.appdev.charting.data.PieDataSet;
+import info.appdev.charting.data.EntryFloat;
+import info.appdev.charting.data.PieEntryFloat;
+import info.appdev.charting.formatter.IValueFormatter;
+import info.appdev.charting.interfaces.datasets.IPieDataSet;
+import info.appdev.charting.renderer.PieChartRenderer;
+import info.appdev.charting.utils.ViewPortHandler;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import xyz.zedler.patrick.grocy.R;
+import xyz.zedler.patrick.grocy.activity.MainActivity;
+import xyz.zedler.patrick.grocy.adapter.SpendingItemAdapter;
+import xyz.zedler.patrick.grocy.behavior.SystemBarBehavior;
+import xyz.zedler.patrick.grocy.databinding.FragmentStockReportSpendingsBinding;
+import xyz.zedler.patrick.grocy.model.Event;
+import xyz.zedler.patrick.grocy.model.SnackbarMessage;
+import xyz.zedler.patrick.grocy.util.ResUtil;
+import xyz.zedler.patrick.grocy.viewmodel.StockReportSpendingsViewModel;
+import xyz.zedler.patrick.grocy.viewmodel.StockReportSpendingsViewModel.SpendingItem;
+
+public class StockReportSpendingsFragment extends BaseFragment {
+
+  private static final String TAG = StockReportSpendingsFragment.class.getSimpleName();
+  private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+  // Material 3 compatible palette — works on both light and dark backgrounds
+  private static final int[] CHART_COLORS = {
+      0xFF6750A4, // M3 primary purple
+      0xFF4CAF50, // green
+      0xFF2196F3, // blue
+      0xFFF44336, // red
+      0xFFFF9800, // orange
+      0xFF00BCD4, // cyan
+      0xFFE91E63, // pink
+      0xFF9C27B0, // deep purple
+      0xFF8BC34A, // light green
+      0xFF03A9F4, // light blue
+      0xFFFFEB3B, // yellow
+      0xFF795548, // brown
+  };
+
+  /** Below this share of the total, a slice is too narrow for the full-size label. */
+  private static final float SMALL_SLICE_PERCENT = 8f;
+  private static final float VALUE_TEXT_SIZE = 11f;
+  private static final float VALUE_TEXT_SIZE_SMALL = 8f;
+
+  private MainActivity activity;
+  private FragmentStockReportSpendingsBinding binding;
+  private StockReportSpendingsViewModel viewModel;
+
+  @Override
+  public View onCreateView(
+      @NonNull LayoutInflater inflater,
+      ViewGroup container,
+      Bundle savedInstanceState
+  ) {
+    binding = FragmentStockReportSpendingsBinding.inflate(inflater, container, false);
+    return binding.getRoot();
+  }
+
+  @Override
+  public void onDestroyView() {
+    super.onDestroyView();
+    binding = null;
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    activity = (MainActivity) requireActivity();
+    viewModel = new ViewModelProvider(this).get(StockReportSpendingsViewModel.class);
+
+    SystemBarBehavior systemBarBehavior = new SystemBarBehavior(activity);
+    systemBarBehavior.setAppBar(binding.appBar);
+    systemBarBehavior.setScroll(binding.scroll, binding.constraint);
+    systemBarBehavior.setUp();
+    activity.setSystemBarBehavior(systemBarBehavior);
+
+    binding.toolbar.setNavigationOnClickListener(v -> activity.navUtil.navigateUp());
+
+    binding.recycler.setLayoutManager(new LinearLayoutManager(requireContext()));
+
+    binding.swipe.setOnRefreshListener(this::loadWithCurrentSelection);
+
+    viewModel.getIsLoadingLive().observe(getViewLifecycleOwner(),
+        loading -> binding.swipe.setRefreshing(loading));
+
+    viewModel.getSpendingItemsLive().observe(getViewLifecycleOwner(), this::updateChart);
+
+    viewModel.getTotalSpendLive().observe(getViewLifecycleOwner(),
+        total -> binding.textTotal.setText(total));
+
+    viewModel.getEventHandler().observeEvent(getViewLifecycleOwner(), event -> {
+      if (event.getType() == Event.SNACKBAR_MESSAGE) {
+        activity.showSnackbar(
+            ((SnackbarMessage) event).getSnackbar(activity.binding.coordinatorMain));
+      }
+    });
+
+    binding.chipGroupDate.setOnCheckedStateChangeListener(
+        (group, checkedIds) -> loadWithCurrentSelection());
+
+    binding.chipGroupBy.setOnCheckedStateChangeListener((group, checkedIds) -> {
+      if (checkedIds.isEmpty()) return;
+      int id = checkedIds.get(0);
+      if (id == R.id.chip_group_product) {
+        viewModel.getGroupByLive().setValue(StockReportSpendingsViewModel.GROUP_BY_PRODUCT);
+      } else if (id == R.id.chip_group_product_group) {
+        viewModel.getGroupByLive().setValue(StockReportSpendingsViewModel.GROUP_BY_PRODUCT_GROUP);
+      } else if (id == R.id.chip_group_store) {
+        viewModel.getGroupByLive().setValue(StockReportSpendingsViewModel.GROUP_BY_STORE);
+      }
+      viewModel.refreshWithGroupBy();
+    });
+
+    setupChart();
+
+    if (savedInstanceState == null) {
+      loadWithCurrentSelection();
+    }
+
+    activity.getScrollBehavior().setNestedOverScrollFixEnabled(true);
+    activity.getScrollBehavior().setUpScroll(binding.appBar, false, binding.scroll, false);
+    activity.getScrollBehavior().setBottomBarVisibility(true);
+    activity.updateBottomAppBar(false, R.menu.menu_empty);
+  }
+
+  private void setupChart() {
+    int colorOnSurface = ResUtil.getColor(requireContext(), R.attr.colorOnSurface);
+    int colorSurface = ResUtil.getColor(requireContext(), R.attr.colorSurface);
+
+    binding.pieChart.setUsePercentValues(true);
+    binding.pieChart.getDescription().setEnabled(false);
+    binding.pieChart.setDrawHole(true);
+    binding.pieChart.setHoleColor(colorSurface);
+    binding.pieChart.setHoleRadius(52f);
+    binding.pieChart.setTransparentCircleRadius(57f);
+    binding.pieChart.setTransparentCircleColor(colorSurface);
+    binding.pieChart.setTransparentCircleAlpha(110);
+    binding.pieChart.setDrawCenterText(false);
+    binding.pieChart.setRotationEnabled(true);
+    binding.pieChart.setHighlightPerTap(true);
+    binding.pieChart.setDrawEntryLabels(false);
+
+    // Legend
+    info.appdev.charting.components.Legend legend = binding.pieChart.getLegend();
+    legend.setEnabled(true);
+    legend.setTextColor(colorOnSurface);
+    legend.setTextSize(12f);
+    legend.setForm(info.appdev.charting.components.Legend.LegendForm.CIRCLE);
+    legend.setFormSize(10f);
+    legend.setWordWrapEnabled(true);
+    legend.setHorizontalAlignment(
+        info.appdev.charting.components.Legend.LegendHorizontalAlignment.CENTER);
+    legend.setVerticalAlignment(
+        info.appdev.charting.components.Legend.LegendVerticalAlignment.BOTTOM);
+    legend.setOrientation(
+        info.appdev.charting.components.Legend.LegendOrientation.HORIZONTAL);
+    legend.setDrawInside(false);
+
+    binding.pieChart.setNoDataText(getString(R.string.error_empty_stock));
+    binding.pieChart.setNoDataTextColor(colorOnSurface);
+  }
+
+  private void updateChart(List<SpendingItem> items) {
+    if (items == null || items.isEmpty()) {
+      binding.pieChart.setVisibility(View.GONE);
+      binding.linearEmpty.setVisibility(View.VISIBLE);
+      binding.recycler.setAdapter(null);
+      return;
+    }
+    binding.pieChart.setVisibility(View.VISIBLE);
+    binding.linearEmpty.setVisibility(View.GONE);
+
+    // Show only top N slices, group the rest as "Other"
+    int maxSlices = 8;
+    List<SpendingItem> chartItems = items.size() > maxSlices
+        ? items.subList(0, maxSlices) : items;
+    double otherTotal = 0;
+    if (items.size() > maxSlices) {
+      for (int i = maxSlices; i < items.size(); i++) {
+        otherTotal += items.get(i).total;
+      }
+    }
+
+    List<PieEntryFloat> entries = new ArrayList<>();
+    for (SpendingItem item : chartItems) {
+      entries.add(new PieEntryFloat((float) item.total, item.name));
+    }
+    if (otherTotal > 0) {
+      entries.add(new PieEntryFloat((float) otherTotal, getString(R.string.subtitle_others)));
+    }
+
+    PieDataSet dataSet = new PieDataSet(entries, "");
+    dataSet.setColors(CHART_COLORS);
+    dataSet.setSliceSpace(2f);
+    dataSet.setSelectionShift(6f);
+    dataSet.setValueLinePart1OffsetPercentage(80f);
+    dataSet.setValueLinePart1Length(0.3f);
+    dataSet.setValueLinePart2Length(0.4f);
+    dataSet.setValueTextColor(Color.WHITE);
+    dataSet.setValueTextSize(VALUE_TEXT_SIZE);
+
+    PieData pieData = new PieData(dataSet);
+    PercentSliceFormatter formatter = new PercentSliceFormatter();
+    pieData.setValueFormatter(formatter);
+    pieData.setValueTextSize(VALUE_TEXT_SIZE);
+    binding.pieChart.setRenderer(new DualSizeValueRenderer(binding.pieChart, formatter));
+    pieData.setValueTextColor(Color.WHITE);
+
+    binding.pieChart.setData(pieData);
+    binding.pieChart.animateY(600, Easing.INSTANCE.getEaseInOutQuad());
+    binding.pieChart.invalidate();
+
+    binding.recycler.setAdapter(
+        new SpendingItemAdapter(items, amount -> viewModel.formatCurrency(amount))
+    );
+  }
+
+  private void loadWithCurrentSelection() {
+    int checkedId = binding.chipGroupDate.getCheckedChipId();
+    String[] range = getDateRange(checkedId);
+    viewModel.loadData(range[0], range[1]);
+  }
+
+  private String[] getDateRange(int chipId) {
+    LocalDate today = LocalDate.now();
+    if (chipId == R.id.chip_last_month) {
+      YearMonth lastMonth = YearMonth.now().minusMonths(1);
+      return new String[]{
+          lastMonth.atDay(1).format(DATE_FMT),
+          lastMonth.atEndOfMonth().format(DATE_FMT)
+      };
+    } else if (chipId == R.id.chip_this_year) {
+      return new String[]{
+          LocalDate.of(today.getYear(), 1, 1).format(DATE_FMT),
+          LocalDate.of(today.getYear(), 12, 31).format(DATE_FMT)
+      };
+    } else {
+      YearMonth thisMonth = YearMonth.now();
+      return new String[]{
+          thisMonth.atDay(1).format(DATE_FMT),
+          thisMonth.atEndOfMonth().format(DATE_FMT)
+      };
+    }
+  }
+
+  @Override
+  public void updateConnectivity(boolean online) {
+    if (!online == viewModel.isOffline()) return;
+    loadWithCurrentSelection();
+  }
+
+  /**
+   * Formats the percentage of a slice, and can restrict itself to either the wide or the narrow
+   * slices so that {@link DualSizeValueRenderer} can draw the two groups at different text sizes.
+   */
+  private static class PercentSliceFormatter implements IValueFormatter {
+
+    static final int ALL = 0;
+    static final int WIDE_ONLY = 1;
+    static final int NARROW_ONLY = 2;
+
+    private final DecimalFormat format =
+        new DecimalFormat("0.0", new DecimalFormatSymbols(Locale.getDefault()));
+    private int mode = ALL;
+
+    void setMode(int mode) {
+      this.mode = mode;
+    }
+
+    @Override
+    public String getFormattedValue(
+        float value, EntryFloat entry, int dataSetIndex, ViewPortHandler viewPortHandler
+    ) {
+      // The chart uses percent values, so value already is the share of the total.
+      boolean narrow = value < SMALL_SLICE_PERCENT;
+      if ((mode == WIDE_ONLY && narrow) || (mode == NARROW_ONLY && !narrow)) {
+        return "";
+      }
+      return format.format(value) + " %";
+    }
+  }
+
+  /**
+   * Draws the labels of narrow slices smaller so that they still fit into their segment.
+   *
+   * <p>The library only supports one value text size per data set, so this renders the values
+   * twice: once for the wide slices at the regular size and once for the narrow ones at the
+   * reduced size. The formatter blanks out whichever group is not part of the current pass, so
+   * no label is drawn twice and the slice geometry never has to be recomputed here.
+   */
+  private static class DualSizeValueRenderer extends PieChartRenderer {
+
+    private final PieChart chart;
+    private final PercentSliceFormatter formatter;
+
+    DualSizeValueRenderer(PieChart chart, PercentSliceFormatter formatter) {
+      super(chart, chart.getAnimator(), chart.getViewPortHandler());
+      this.chart = chart;
+      this.formatter = formatter;
+    }
+
+    @Override
+    public void drawValues(Canvas c) {
+      PieData data = chart.getData();
+      if (data == null) {
+        return;
+      }
+      IPieDataSet dataSet = data.getDataSet();
+      if (dataSet == null) {
+        return;
+      }
+      drawPass(c, dataSet, PercentSliceFormatter.WIDE_ONLY, VALUE_TEXT_SIZE);
+      drawPass(c, dataSet, PercentSliceFormatter.NARROW_ONLY, VALUE_TEXT_SIZE_SMALL);
+      formatter.setMode(PercentSliceFormatter.ALL);
+      dataSet.setValueTextSize(VALUE_TEXT_SIZE);
+    }
+
+    private void drawPass(Canvas c, IPieDataSet dataSet, int mode, float textSize) {
+      formatter.setMode(mode);
+      dataSet.setValueTextSize(textSize);
+      super.drawValues(c);
+    }
+  }
+
+  @NonNull
+  @Override
+  public String toString() {
+    return TAG;
+  }
+}

--- a/app/src/main/java/xyz/zedler/patrick/grocy/model/StockLogEntry.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/model/StockLogEntry.java
@@ -329,4 +329,36 @@ public class StockLogEntry implements Parcelable {
   ) {
     return getStockLogEntries(dlHelper, limit, offset, -1, onResponseListener, null);
   }
+
+  public static QueueItem getPurchaseEntries(
+      DownloadHelper dlHelper,
+      String startDate,
+      String endDate,
+      OnObjectsResponseListener<StockLogEntry> onResponseListener,
+      OnErrorListener onErrorListener
+  ) {
+    return new QueueItem() {
+      @Override
+      public void perform(
+          @Nullable OnStringResponseListener responseListener,
+          @Nullable OnMultiTypeErrorListener errorListener,
+          @Nullable String uuid
+      ) {
+        dlHelper.get(
+            dlHelper.grocyApi.getPurchaseStockLog(startDate, endDate),
+            uuid,
+            response -> {
+              Type type = new TypeToken<ArrayList<StockLogEntry>>() {}.getType();
+              ArrayList<StockLogEntry> entries = dlHelper.gson.fromJson(response, type);
+              if (onResponseListener != null) onResponseListener.onResponse(entries);
+              if (responseListener != null) responseListener.onResponse(response);
+            },
+            error -> {
+              if (onErrorListener != null) onErrorListener.onError(error);
+              if (errorListener != null) errorListener.onError(error);
+            }
+        );
+      }
+    };
+  }
 }

--- a/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/StockReportSpendingsViewModel.java
+++ b/app/src/main/java/xyz/zedler/patrick/grocy/viewmodel/StockReportSpendingsViewModel.java
@@ -1,0 +1,261 @@
+/*
+ * This file is part of Grocy Android.
+ *
+ * Grocy Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grocy Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grocy Android. If not, see http://www.gnu.org/licenses/.
+ *
+ * Copyright (c) 2020-2024 by Patrick Zedler and Dominic Zedler
+ * Copyright (c) 2024-2026 by Patrick Zedler
+ */
+
+package xyz.zedler.patrick.grocy.viewmodel;
+
+import android.app.Application;
+import androidx.annotation.NonNull;
+import androidx.lifecycle.MutableLiveData;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import xyz.zedler.patrick.grocy.Constants.PREF;
+import xyz.zedler.patrick.grocy.R;
+import xyz.zedler.patrick.grocy.database.AppDatabase;
+import xyz.zedler.patrick.grocy.helper.DownloadHelper;
+import xyz.zedler.patrick.grocy.model.InfoFullscreen;
+import xyz.zedler.patrick.grocy.model.Product;
+import xyz.zedler.patrick.grocy.model.ProductGroup;
+import xyz.zedler.patrick.grocy.model.StockLogEntry;
+import xyz.zedler.patrick.grocy.model.Store;
+import xyz.zedler.patrick.grocy.web.NetworkQueue;
+
+public class StockReportSpendingsViewModel extends BaseViewModel {
+
+  private static final String TAG = StockReportSpendingsViewModel.class.getSimpleName();
+
+  public static final int GROUP_BY_PRODUCT = 0;
+  public static final int GROUP_BY_PRODUCT_GROUP = 1;
+  public static final int GROUP_BY_STORE = 2;
+
+  private final DownloadHelper dlHelper;
+  private final AppDatabase appDatabase;
+
+  private final MutableLiveData<Boolean> isLoadingLive;
+  private final MutableLiveData<InfoFullscreen> infoFullscreenLive;
+  private final MutableLiveData<List<SpendingItem>> spendingItemsLive;
+  private final MutableLiveData<String> totalSpendLive;
+  private final MutableLiveData<Integer> groupByLive;
+
+  private List<StockLogEntry> purchaseEntries;
+  private List<Product> products;
+  private List<ProductGroup> productGroups;
+  private List<Store> stores;
+
+  public static class SpendingItem {
+    public final String name;
+    public final double total;
+
+    public SpendingItem(String name, double total) {
+      this.name = name;
+      this.total = total;
+    }
+  }
+
+  public StockReportSpendingsViewModel(@NonNull Application application) {
+    super(application);
+
+    isLoadingLive = new MutableLiveData<>(false);
+    dlHelper = new DownloadHelper(getApplication(), TAG, isLoadingLive::setValue, getOfflineLive());
+    appDatabase = AppDatabase.getAppDatabase(application);
+    infoFullscreenLive = new MutableLiveData<>();
+    spendingItemsLive = new MutableLiveData<>();
+    totalSpendLive = new MutableLiveData<>();
+    groupByLive = new MutableLiveData<>(GROUP_BY_PRODUCT);
+  }
+
+  public void loadData(String startDate, String endDate) {
+    // Products, product groups and stores are only read from the database below, so make sure
+    // they are actually there — otherwise group labels fall back to raw ids.
+    dlHelper.updateData(
+        updated -> loadFromDatabase(startDate, endDate),
+        error -> onError(error, TAG),
+        false,
+        true,
+        Product.class,
+        ProductGroup.class,
+        Store.class
+    );
+  }
+
+  private void loadFromDatabase(String startDate, String endDate) {
+    Single.zip(
+        appDatabase.productDao().getProducts(),
+        appDatabase.productGroupDao().getProductGroups(),
+        appDatabase.storeDao().getStores(),
+        (p, pg, s) -> {
+          this.products = p;
+          this.productGroups = pg;
+          this.stores = s;
+          return true;
+        }
+    )
+    .subscribeOn(Schedulers.io())
+    .observeOn(AndroidSchedulers.mainThread())
+    .doOnSuccess(ok -> fetchPurchaseEntries(startDate, endDate))
+    .doOnError(e -> onError(e, TAG))
+    .onErrorComplete()
+    .subscribe();
+  }
+
+  private void fetchPurchaseEntries(String startDate, String endDate) {
+    NetworkQueue queue = dlHelper.newQueue(
+        updated -> {
+          if (isOffline()) setOfflineLive(false);
+          aggregateAndDisplay();
+        },
+        error -> onError(error, TAG)
+    );
+    queue.append(StockLogEntry.getPurchaseEntries(
+        dlHelper, startDate, endDate,
+        items -> this.purchaseEntries = items,
+        null
+    ));
+    queue.start();
+  }
+
+  public void refreshWithGroupBy() {
+    aggregateAndDisplay();
+  }
+
+  private void aggregateAndDisplay() {
+    if (purchaseEntries == null) return;
+    int groupBy = groupByLive.getValue() != null ? groupByLive.getValue() : GROUP_BY_PRODUCT;
+
+    Map<String, Double> aggregated = new HashMap<>();
+
+    for (StockLogEntry entry : purchaseEntries) {
+      String key = resolveGroupKey(entry, groupBy);
+      double cost = totalCost(entry);
+      aggregated.put(key, aggregated.getOrDefault(key, 0.0) + cost);
+    }
+
+    List<SpendingItem> items = new ArrayList<>();
+    double total = 0;
+    for (Map.Entry<String, Double> e : aggregated.entrySet()) {
+      items.add(new SpendingItem(e.getKey(), e.getValue()));
+      total += e.getValue();
+    }
+    Collections.sort(items, (a, b) -> Double.compare(b.total, a.total));
+
+    if (items.isEmpty()) {
+      infoFullscreenLive.setValue(new InfoFullscreen(InfoFullscreen.INFO_EMPTY_STOCK));
+      spendingItemsLive.setValue(new ArrayList<>());
+      totalSpendLive.setValue(formatCurrency(0));
+    } else {
+      infoFullscreenLive.setValue(null);
+      spendingItemsLive.setValue(items);
+      totalSpendLive.setValue(formatCurrency(total));
+    }
+  }
+
+  private double totalCost(StockLogEntry entry) {
+    try {
+      String priceStr = entry.getPrice();
+      if (priceStr == null || priceStr.isEmpty()) return 0;
+      double amount = Double.parseDouble(entry.getAmount());
+      double price = Double.parseDouble(priceStr);
+      return Math.abs(amount) * price;
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  private String resolveGroupKey(StockLogEntry entry, int groupBy) {
+    switch (groupBy) {
+      case GROUP_BY_PRODUCT: {
+        if (products == null) return String.valueOf(entry.getProductId());
+        for (Product p : products) {
+          if (p.getId() == entry.getProductId()) return p.getName();
+        }
+        return String.valueOf(entry.getProductId());
+      }
+      case GROUP_BY_PRODUCT_GROUP: {
+        if (products == null || productGroups == null) return getString(R.string.subtitle_unknown);
+        String groupId = null;
+        for (Product p : products) {
+          if (p.getId() == entry.getProductId()) {
+            groupId = p.getProductGroupId();
+            break;
+          }
+        }
+        if (groupId == null) return getString(R.string.subtitle_none);
+        for (ProductGroup g : productGroups) {
+          if (String.valueOf(g.getId()).equals(groupId)) return g.getName();
+        }
+        return getString(R.string.subtitle_unknown);
+      }
+      case GROUP_BY_STORE: {
+        String locationId = entry.getShoppingLocationId();
+        if (locationId == null || locationId.isEmpty()) return getString(R.string.subtitle_none);
+        if (stores == null) return locationId;
+        try {
+          int lid = Integer.parseInt(locationId);
+          for (Store s : stores) {
+            if (s.getId() == lid) return s.getName();
+          }
+        } catch (NumberFormatException ignored) {}
+        return locationId;
+      }
+      default:
+        return String.valueOf(entry.getProductId());
+    }
+  }
+
+  public String formatCurrency(double amount) {
+    String currency = getSharedPrefs().getString(PREF.CURRENCY, "");
+    DecimalFormat df = new DecimalFormat("0.00", new DecimalFormatSymbols(Locale.getDefault()));
+    return df.format(amount) + (currency.isEmpty() ? "" : " " + currency);
+  }
+
+  public MutableLiveData<Boolean> getIsLoadingLive() {
+    return isLoadingLive;
+  }
+
+  public MutableLiveData<InfoFullscreen> getInfoFullscreenLive() {
+    return infoFullscreenLive;
+  }
+
+  public MutableLiveData<List<SpendingItem>> getSpendingItemsLive() {
+    return spendingItemsLive;
+  }
+
+  public MutableLiveData<String> getTotalSpendLive() {
+    return totalSpendLive;
+  }
+
+  public MutableLiveData<Integer> getGroupByLive() {
+    return groupByLive;
+  }
+
+  @Override
+  protected void onCleared() {
+    dlHelper.destroy();
+    super.onCleared();
+  }
+}

--- a/app/src/main/res/layout/fragment_stock_report_spendings.xml
+++ b/app/src/main/res/layout/fragment_stock_report_spendings.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ This file is part of Grocy Android.
+  ~
+  ~ Grocy Android is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Grocy Android is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Grocy Android. If not, see http://www.gnu.org/licenses/.
+  ~
+  ~ Copyright (c) 2020-2024 by Patrick Zedler and Dominic Zedler
+  ~ Copyright (c) 2024-2026 by Patrick Zedler
+  -->
+
+<layout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+    <import type="android.view.View" />
+  </data>
+
+  <androidx.coordinatorlayout.widget.CoordinatorLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
+
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/app_bar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
+
+      <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Grocy.Toolbar.Back"
+        app:title="@string/title_stock_report_spendings" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <xyz.zedler.patrick.grocy.view.swiperefreshlayout.CustomSwipeRefreshLayout
+      android:id="@+id/swipe"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:layout_marginTop="?attr/actionBarSize"
+      android:overScrollMode="never">
+
+      <FrameLayout
+        android:id="@+id/frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.core.widget.NestedScrollView
+          android:id="@+id/scroll"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          android:overScrollMode="never">
+
+          <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/constraint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:paddingBottom="@dimen/global_scroll_bottom_padding">
+
+            <LinearLayout
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              app:layout_constraintTop_toTopOf="parent"
+              app:layout_constraintWidth_max="@dimen/max_content_width"
+              app:layout_constraintStart_toStartOf="parent"
+              app:layout_constraintEnd_toEndOf="parent">
+
+              <info.appdev.charting.charts.PieChart
+                android:id="@+id/pie_chart"
+                android:layout_width="match_parent"
+                android:layout_height="280dp"
+                android:layout_marginTop="8dp"
+                android:visibility="gone" />
+
+              <LinearLayout
+                android:id="@+id/linear_empty"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:paddingTop="32dp"
+                android:paddingBottom="16dp"
+                android:visibility="gone">
+
+                <TextView
+                  style="@style/Widget.Grocy.TextView.LabelLarge"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:text="@string/error_empty_stock"
+                  android:textColor="?attr/colorOnSurfaceVariant" />
+
+              </LinearLayout>
+
+              <LinearLayout
+                android:id="@+id/linear_filters"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp">
+
+                <TextView
+                  style="@style/Widget.Grocy.TextView.LabelLarge"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:paddingBottom="8dp"
+                  android:text="@string/property_date_range" />
+
+                <com.google.android.material.chip.ChipGroup
+                  android:id="@+id/chip_group_date"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  app:singleSelection="true"
+                  app:selectionRequired="true">
+
+                  <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_this_month"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/date_range_this_month"
+                    android:checked="true" />
+
+                  <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_last_month"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/date_range_last_month" />
+
+                  <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_this_year"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/date_range_this_year" />
+
+                </com.google.android.material.chip.ChipGroup>
+
+                <TextView
+                  style="@style/Widget.Grocy.TextView.LabelLarge"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:paddingTop="12dp"
+                  android:paddingBottom="8dp"
+                  android:text="@string/property_group_by_label" />
+
+                <com.google.android.material.chip.ChipGroup
+                  android:id="@+id/chip_group_by"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  app:singleSelection="true"
+                  app:selectionRequired="true">
+
+                  <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_group_product"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/property_product"
+                    android:checked="true" />
+
+                  <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_group_product_group"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/property_product_group" />
+
+                  <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_group_store"
+                    style="@style/Widget.Material3.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/property_store" />
+
+                </com.google.android.material.chip.ChipGroup>
+
+              </LinearLayout>
+
+              <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp" />
+
+              <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="12dp"
+                android:paddingBottom="4dp">
+
+                <TextView
+                  style="@style/Widget.Grocy.TextView.LabelLarge"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:text="@string/title_total" />
+
+                <TextView
+                  android:id="@+id/text_total"
+                  style="@style/Widget.Grocy.TextView.LabelLarge"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:layout_marginStart="8dp"
+                  android:text="–" />
+
+              </LinearLayout>
+
+              <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:overScrollMode="never"
+                android:nestedScrollingEnabled="false" />
+
+            </LinearLayout>
+
+          </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </androidx.core.widget.NestedScrollView>
+
+      </FrameLayout>
+
+    </xyz.zedler.patrick.grocy.view.swiperefreshlayout.CustomSwipeRefreshLayout>
+
+  </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+</layout>

--- a/app/src/main/res/layout/row_spending_item.xml
+++ b/app/src/main/res/layout/row_spending_item.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ This file is part of Grocy Android.
+  ~
+  ~ Grocy Android is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Grocy Android is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Grocy Android. If not, see http://www.gnu.org/licenses/.
+  ~
+  ~ Copyright (c) 2020-2024 by Patrick Zedler and Dominic Zedler
+  ~ Copyright (c) 2024-2026 by Patrick Zedler
+  -->
+
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  style="@style/Widget.Grocy.LinearLayout.ListItem.TwoLine"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content">
+
+  <ImageView
+    style="@style/Widget.Grocy.ImageView.ListItem.Icon"
+    android:importantForAccessibility="no"
+    android:src="@drawable/ic_round_cash_multiple" />
+
+  <LinearLayout style="@style/Widget.Grocy.LinearLayout.ListItem.TextBox.Stretch">
+
+    <TextView
+      android:id="@+id/text_name"
+      style="@style/Widget.Grocy.TextView.ListItem.Title" />
+
+    <TextView
+      android:id="@+id/text_amount"
+      style="@style/Widget.Grocy.TextView.ListItem.Description" />
+
+  </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_stock.xml
+++ b/app/src/main/res/menu/menu_stock.xml
@@ -42,4 +42,10 @@
     android:icon="@drawable/ic_round_format_list_numbered"
     app:showAsAction="ifRoom" />
 
+  <item
+    android:id="@+id/action_stock_report_spendings"
+    android:title="@string/title_stock_report_spendings"
+    android:icon="@drawable/ic_round_cash_multiple"
+    app:showAsAction="ifRoom" />
+
 </menu>

--- a/app/src/main/res/navigation/navigation_main.xml
+++ b/app/src/main/res/navigation/navigation_main.xml
@@ -1010,6 +1010,9 @@
     <action
       android:id="@+id/action_stockOverviewFragment_to_stockJournalFragment"
       app:destination="@id/stockJournalFragment" />
+    <action
+      android:id="@+id/action_stockOverviewFragment_to_stockReportSpendingsFragment"
+      app:destination="@id/stockReportSpendingsFragment" />
   </fragment>
   <fragment
     android:id="@+id/chooseProductFragment"
@@ -1204,6 +1207,11 @@
     android:name="xyz.zedler.patrick.grocy.fragment.StockJournalFragment"
     android:label="StockJournalFragment"
     tools:layout="@layout/fragment_stock_journal"/>
+  <fragment
+    android:id="@+id/stockReportSpendingsFragment"
+    android:name="xyz.zedler.patrick.grocy.fragment.StockReportSpendingsFragment"
+    android:label="StockReportSpendingsFragment"
+    tools:layout="@layout/fragment_stock_report_spendings"/>
   <fragment
     android:id="@+id/editorHtmlFragment2"
     android:name="xyz.zedler.patrick.grocy.fragment.EditorHtmlFragment"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1328,6 +1328,14 @@
   <string name="mtm_valid_for">Zertifikat gültig für:</string>
   <string name="mtm_decision_always">Immer</string>
   <string name="mtm_decision_once">Einmalig</string>
+  <string name="title_stock_report_spendings">Ausgaben-Report</string>
+  <string name="subtitle_others">Sonstige</string>
+  <string name="property_date_range">Zeitraum</string>
+  <string name="property_group_by_label">Gruppieren nach</string>
+  <string name="title_total">Gesamt:</string>
+  <string name="date_range_this_month">Dieser Monat</string>
+  <string name="date_range_last_month">Letzter Monat</string>
+  <string name="date_range_this_year">Dieses Jahr</string>
   <string name="mtm_notification_channel">Sicherheit</string>
   <string name="mtm_notification">Überprüfung des Zertifikats</string>
   <string name="mtm_error_keystore">Fehler beim Laden des Keystores aus Datei</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -594,6 +594,7 @@
   <string name="title_stock_entries">Stock entries</string>
   <string name="title_stock_entry">Stock entry</string>
   <string name="title_stock_journal">Stock journal</string>
+  <string name="title_stock_report_spendings">Spending report</string>
   <string name="title_shopping_list">Shopping list</string>
   <string name="title_feedback">Feedback</string>
   <string name="title_settings">Settings</string>
@@ -719,6 +720,7 @@
 
   <string name="subtitle_barcodes_will_be_added">There are stored barcodes, which are added to the product with the save operation.</string>
   <string name="subtitle_unknown">Unknown</string>
+  <string name="subtitle_others">Others</string>
   <!-- Like the word 'supported' from 'This version is supported.'-->
   <string name="subtitle_supported">Supported</string>
   <!-- Like the words 'not supported' from 'This version is not supported.'-->
@@ -1031,6 +1033,12 @@
   <string name="property_userfield_value_without_space">%1$s:%2$s</string>
   <string name="property_task_category">Task category</string>
   <string name="property_task_categories">Task categories</string>
+  <string name="property_date_range">Date range</string>
+  <string name="property_group_by_label">Group by</string>
+  <string name="title_total">Total:</string>
+  <string name="date_range_this_month">This month</string>
+  <string name="date_range_last_month">Last month</string>
+  <string name="date_range_this_year">This year</string>
   <string name="property_calories">Calories</string>
   <string name="property_calories_unit">Calories (unit)</string>
   <string name="property_calories_total">Calories (total)</string>

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,6 +32,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = "https://a8c-libs.s3.amazonaws.com/android" }
+        maven { url = "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
Closes #995 

Implements the report discussed in the issue.

## Commits

Split by layer, so the build change, the query and the UI can be read apart from one another. 

| Commit | Layer |
|---|---|
| Add AndroidChart dependency | build |
| Query purchase transactions from the stock log | API |
| Add spending aggregation view model | logic |
| Add spending report screen | UI |
| Add spending report entry to the stock overview menu | entry point |

## Query and arithmetic

Built on the `stock_log` source proposed in the issue:

```
/objects/stock_log?query[]=transaction_type=purchase
                  &query[]=undone=0
                  &query[]=purchased_date>=<start>
                  &query[]=purchased_date<=<end>
```

Per row the spend is `|amount| × price`. Two details worth confirming against how the web report behaves:

- Rows with a null price contribute **zero** rather than being dropped,   so a row's absence from the total never silently changes the row count.
- `amount` is taken as an absolute value, so a correction row recorded   with a negative amount still registers as spend rather than subtracting
  from the period.

## Loading

Products, product groups and stores are updated, then read back in one `Single.zip()` before the purchase log is fetched. The update matters because those three resolve the grouping labels: without it, whichever entity no other screen had synced yet would leave raw ids on screen. It is not forced, so it is a cheap no-op once the data is current.

Switching the grouping afterwards re-aggregates in memory with no second round trip; only a period change or pull-to-refresh hits the network.

## Chart decisions

The top **eight** slices are shown individually and the remainder is collapsed into a single *Others* slice; past that the legend stops being readable at phone width. The list below is not truncated, so the full breakdown stays available.

Labels on narrow slices are drawn smaller so they still fit their segment. The library supports only one value text size per data set, so rather than reimplementing the slice geometry, the renderer draws the values in two passes — wide slices at the regular size, narrow ones reduced — with the formatter blanking out whichever group is not part of the current pass. That is the one piece of custom drawing code here and the part I would look at first in review.

Slice colours are a fixed twelve-colour palette rather than theme colours, because adjacent slices have to stay distinguishable from one another. The chart hole, legend text and surrounding chrome do follow the active theme in both light and dark.

For an empty period the chart is hidden and an inline label takes its place. Deliberately not `InfoFullscreenHelper`: that helper injects into a container sitting behind the scroll view, which on this screen draws the illustration underneath the filter chips.

## Dependency

`com.github.AppDevNext.AndroidChart:chartLib:5.2.4`, which also required adding the JitPack repository to `settings.gradle` — Maven Central holds only snapshots of it. This is the only addition to the dependency set.

It is Apache 2.0 and needs minSdk 23, both matching this project, and the Kotlin standard library it brings was already on the runtime classpath, so it adds no new runtime. 

## Formatting

Amounts use the configured `PREF.CURRENCY` with the device locale's decimal separators. English and German strings are included.

## Testing

Ran on device Pixel 9 Pro running LineageOS 24 against a production server across all three periods and all three groupings, with the resulting figures reconciled line by line against the same report in the web UI. Also covered: a period with no purchases, a dataset with more than eight groups to confirm the *Others* collapse, and purchases with a missing price and with a null shopping location.


